### PR TITLE
refactor: Improve markdown code block handling with pre-compiled regex

### DIFF
--- a/tests/unit/test_markdown.py
+++ b/tests/unit/test_markdown.py
@@ -150,3 +150,28 @@ This is a new paragraph."""
         result = markdown_to_html(markdown)
         # Should have paragraphs (with note.com UUID attributes)
         assert "<p " in result or "<p>" in result
+
+    def test_code_block_preserves_newlines(self) -> None:
+        """Test that code blocks preserve internal newlines.
+
+        note.com requires:
+        - <pre class="codeBlock"> format
+        - Actual newlines preserved inside code blocks
+        """
+        markdown = """```python
+def hello():
+    print("Hello")
+    return True
+```"""
+        result = markdown_to_html(markdown)
+        # Code block must be in note.com format (attribute order matters)
+        assert 'class="codeBlock"' in result
+        assert "<pre " in result
+        assert "<code>" in result  # No language class
+        # The newlines between code lines must be preserved as actual newlines
+        assert "\n" in result
+        # Verify the code content is intact
+        assert "def hello():" in result
+        assert 'print("Hello")' in result or "print(&quot;Hello&quot;)" in result
+        # Verify newlines are between code lines
+        assert "def hello():\n" in result


### PR DESCRIPTION
## Summary

- 正規表現パターンをモジュールレベルで事前コンパイルしパフォーマンス向上
- `_convert_code_blocks_to_note_format()` 関数を追加し、コードブロック内の改行を保持
- `<pre>` タグの処理を汎用UUID付与から分離
- コードブロック改行保持のテストを追加

## Background

note.com APIがコードブロック内の改行を正しく処理するための準備として、HTML生成時に改行を適切に保持するよう改善しました。

## Test plan

- [x] `uv run pytest tests/unit/test_markdown.py -v` - 20件すべて通過
- [x] `uv run ruff check --fix . && uv run ruff format . && uv run mypy .` - すべて通過