### PR TITLE
test: Add h3 heading conversion test (closes #8)

### DIFF
--- a/tests/unit/test_markdown.py
+++ b/tests/unit/test_markdown.py
@@ -19,6 +19,12 @@ class TestMarkdownToHtml:
         assert "<h2 " in result or "<h2>" in result
         assert "Heading 2" in result
 
+    def test_heading_level_3(self) -> None:
+        """Test converting level 3 headings (small heading)."""
+        result = markdown_to_html("### Heading 3")
+        assert "<h3 " in result or "<h3>" in result
+        assert "Heading 3" in result
+
     def test_paragraph_conversion(self) -> None:
         """Test converting paragraphs."""
         result = markdown_to_html("This is a paragraph.")


### PR DESCRIPTION
## Summary

- h3見出し（`### text`）の変換テストを追加
- Issue #8 の検証タスク完了

## Changes

- `tests/unit/test_markdown.py`: `test_heading_level_3` を追加

## Verification

- ✅ ユニットテスト 150件 全通過
- ✅ ruff check / format / mypy 全通過
- ✅ Manual E2E: 記事 `n47350fa682db` でh2/h3見出しが正しく保存されることを確認

## Test plan

- [x] `uv run pytest tests/unit/test_markdown.py::TestMarkdownToHtml::test_heading_level_3 -v`
- [x] 品質チェック通過

Closes #8