### PR TITLE
fix: Use note.com URL pattern for article edit/get operations

### DIFF
--- a/src/note_mcp/browser/get_article.py
+++ b/src/note_mcp/browser/get_article.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
     from note_mcp.models import Session
 
 
-# note.com editor URL
-NOTE_EDITOR_URL = "https://editor.note.com"
+# note.com edit URL (accessed via note.com for proper auth flow)
+NOTE_EDIT_URL = "https://note.com/notes"
 
 
 async def get_article_via_browser(
@@ -55,7 +55,7 @@ async def get_article_via_browser(
     await page.context.add_cookies(playwright_cookies)  # type: ignore[arg-type]
 
     # Navigate to article edit page
-    edit_url = f"{NOTE_EDITOR_URL}/notes/{article_id}/edit/"
+    edit_url = f"{NOTE_EDIT_URL}/{article_id}/edit"
     await page.goto(edit_url, wait_until="domcontentloaded")
 
     # Wait for network to be idle (all initial requests completed)
@@ -64,9 +64,10 @@ async def get_article_via_browser(
 
     await asyncio.sleep(2)  # Additional wait for JavaScript initialization
 
-    # Check if we're on the right page
+    # Check if we're on the right page (allow various redirect patterns)
     current_url = page.url
-    if article_id not in current_url:
+    valid_patterns = [f"/notes/{article_id}", f"/n/{article_id}", "editor.note.com"]
+    if not any(pattern in current_url for pattern in valid_patterns):
         raise RuntimeError(f"Failed to navigate to article edit page. Current URL: {current_url}")
 
     # Wait for the editor to be fully ready


### PR DESCRIPTION
## Summary

- ProseMirrorエディタが既存記事編集ページで読み込まれない問題を修正
- `editor.note.com` への直接アクセスから `note.com/notes/{id}/edit` 経由に変更
- 認証フローが正しく動作するようになった

## Changes

- `src/note_mcp/browser/get_article.py` - URL pattern変更、柔軟なURL検証追加
- `src/note_mcp/browser/update_article.py` - URL pattern変更、柔軟なURL検証追加

## Root Cause

`editor.note.com` への直接アクセスでは認証が正しく確立されず、ProseMirrorエディタの読み込みがタイムアウトしていた。`note.com` 経由でアクセスすることで、リダイレクトを通じて認証が正しく処理される。

## Testing

- ✅ 全190テストパス
- ✅ 手動テストで `note_get_article` 確認
- ✅ 手動テストで `note_update_article` 確認

Closes #17