### PR TITLE
fix(api): correct list_articles endpoint to return drafts (#43)

### DIFF
--- a/src/note_mcp/models.py
+++ b/src/note_mcp/models.py
@@ -252,10 +252,18 @@ def from_api_response(data: dict[str, object]) -> Article:
     if not isinstance(status_str, str) or not status_str:
         status_str = "draft"
 
+    # Extract title: use "name" field, fallback to "noteDraft.name" for drafts
+    title = data.get("name")
+    if not title:
+        note_draft = data.get("noteDraft")
+        if isinstance(note_draft, dict):
+            title = note_draft.get("name")
+    title_str = str(title) if title else ""
+
     return Article(
         id=str(data.get("id", "")),
         key=str(data.get("key", "")),
-        title=str(data.get("name", "")),
+        title=title_str,
         body=str(data.get("body", "")),
         status=ArticleStatus(status_str),
         tags=tags,


### PR DESCRIPTION
## Summary
- `note_list_articles`が下書き記事を返さない問題を修正
- APIエンドポイントを`/v2/creators/{username}/contents`から`/v2/note_list/contents`に変更
- レスポンス解析を修正（`contents`→`notes`キー）
- 下書き記事のタイトル取得を修正（`noteDraft.name`へのフォールバック追加）

## Root Cause
- 旧エンドポイントは公開記事のみを返し、下書きを返さなかった
- ブラウザのネットワーク監視で正しいエンドポイントを特定

## Test Plan
- [x] 品質チェック通過（ruff, mypy）
- [x] 全345テスト通過
- [x] 実際のnote.comアカウントで82件の記事が正しく取得されることを確認

Fixes #43