### PR TITLE
feat(#116): 埋め込みURL処理をAPI経由に移行

### DIFF
--- a/src/note_mcp/api/embeds.py
+++ b/src/note_mcp/api/embeds.py
@@ -1,0 +1,89 @@
+"""Embed URL detection and HTML generation for note.com.
+
+This module provides functions for detecting embed URLs (YouTube, Twitter, note.com)
+and generating the required HTML structure for note.com embeds.
+
+This is the single source of truth for embed URL patterns (DRY principle).
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import uuid
+
+# Embed URL patterns (single source of truth - DRY principle)
+# YouTube: youtube.com/watch?v=xxx or youtu.be/xxx
+YOUTUBE_PATTERN = re.compile(r"^https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)[\w-]+$")
+
+# Twitter/X: twitter.com/user/status/xxx or x.com/user/status/xxx
+TWITTER_PATTERN = re.compile(r"^https?://(?:www\.)?(?:twitter\.com|x\.com)/\w+/status/\d+$")
+
+# note.com: note.com/user/n/xxx
+NOTE_PATTERN = re.compile(r"^https?://note\.com/\w+/n/\w+$")
+
+
+def get_embed_service(url: str) -> str | None:
+    """Get embed service type from URL.
+
+    Args:
+        url: The URL to check.
+
+    Returns:
+        Service type ('youtube', 'twitter', 'note') or None if unsupported.
+    """
+    if YOUTUBE_PATTERN.match(url):
+        return "youtube"
+    if TWITTER_PATTERN.match(url):
+        return "twitter"
+    if NOTE_PATTERN.match(url):
+        return "note"
+    return None
+
+
+def is_embed_url(url: str) -> bool:
+    """Check if URL is a supported embed URL.
+
+    Args:
+        url: The URL to check.
+
+    Returns:
+        True if the URL is a supported embed URL, False otherwise.
+    """
+    return get_embed_service(url) is not None
+
+
+def generate_embed_html(url: str, service: str | None = None) -> str:
+    """Generate embed HTML for note.com.
+
+    Creates a figure element with the required attributes for note.com
+    to render the embed (iframe is rendered client-side by note.com frontend).
+
+    Args:
+        url: Original URL (YouTube, Twitter, note.com).
+        service: Service type ('youtube', 'twitter', 'note').
+                 If None, auto-detected from URL.
+
+    Returns:
+        HTML figure element string.
+
+    Raises:
+        ValueError: If URL is not a supported embed URL.
+    """
+    if service is None:
+        service = get_embed_service(url)
+
+    if service is None:
+        raise ValueError(f"Unsupported embed URL: {url}")
+
+    element_id = str(uuid.uuid4())
+    embed_key = f"emb{uuid.uuid4().hex[:13]}"
+    escaped_url = html.escape(url, quote=True)
+
+    return (
+        f'<figure name="{element_id}" id="{element_id}" '
+        f'data-src="{escaped_url}" '
+        f'embedded-service="{service}" '
+        f'embedded-content-key="{embed_key}" '
+        f'contenteditable="false"></figure>'
+    )

--- a/src/note_mcp/browser/typing_helpers.py
+++ b/src/note_mcp/browser/typing_helpers.py
@@ -34,6 +34,8 @@ import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from note_mcp.api.embeds import is_embed_url as _api_is_embed_url
+
 if TYPE_CHECKING:
     pass
 
@@ -102,11 +104,8 @@ _ALIGN_RIGHT_PLACEHOLDER = "§§ALIGN_RIGHT§§"
 _ALIGN_LEFT_PLACEHOLDER = "§§ALIGN_LEFT§§"
 _ALIGN_END_PLACEHOLDER = "§§/ALIGN§§"
 
-# Embed URL patterns (must match insert_embed.py)
+# Embed URL patterns are defined in api.embeds (DRY principle - Issue #116)
 # Supported services: YouTube, Twitter/X, note.com articles
-_EMBED_YOUTUBE_PATTERN = re.compile(r"^https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)[\w-]+$")
-_EMBED_TWITTER_PATTERN = re.compile(r"^https?://(?:www\.)?(?:twitter\.com|x\.com)/\w+/status/\d+$")
-_EMBED_NOTE_PATTERN = re.compile(r"^https?://note\.com/\w+/n/\w+$")
 
 # Embed placeholder format: §§EMBED:url§§
 _EMBED_PLACEHOLDER_START = "§§EMBED:"
@@ -116,18 +115,17 @@ _EMBED_PLACEHOLDER_END = "§§"
 def _is_embed_url(url: str) -> bool:
     """Check if URL should be embedded (YouTube, Twitter, note.com).
 
+    Delegates to api.embeds.is_embed_url (DRY principle - Issue #116).
+
     Args:
         url: URL string to check.
 
     Returns:
         True if URL matches a supported embed service.
     """
-    is_youtube = bool(_EMBED_YOUTUBE_PATTERN.match(url))
-    is_twitter = bool(_EMBED_TWITTER_PATTERN.match(url))
-    is_note = bool(_EMBED_NOTE_PATTERN.match(url))
-    is_embed = is_youtube or is_twitter or is_note
+    is_embed = _api_is_embed_url(url)
     if is_embed:
-        logger.info(f"_is_embed_url: {url} -> youtube={is_youtube}, twitter={is_twitter}, note={is_note}")
+        logger.info(f"_is_embed_url: {url} -> embed=True")
     return is_embed
 
 

--- a/tests/e2e/test_embed_api.py
+++ b/tests/e2e/test_embed_api.py
@@ -1,0 +1,326 @@
+"""E2E tests for embed URL API conversion (Issue #116).
+
+Tests creating note.com articles with embed URLs (YouTube, Twitter, note.com)
+via API without browser automation.
+
+Each test validates:
+1. API response contains expected success message
+2. Embed URLs are converted to figure elements
+3. Preview page shows embed card correctly
+
+Run with: uv run pytest tests/e2e/test_embed_api.py -v
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from note_mcp.server import note_create_draft, note_get_article
+from tests.e2e.helpers import (
+    extract_article_id,
+    preview_page_context,
+)
+
+if TYPE_CHECKING:
+    from note_mcp.models import Session
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_auth,
+    pytest.mark.asyncio,
+]
+
+
+class TestEmbedUrlApiConversion:
+    """Test embed URL conversion via API (no browser required)."""
+
+    async def test_youtube_embed_via_api(
+        self,
+        real_session: Session,
+    ) -> None:
+        """YouTube URLがAPIでfigure要素に変換される.
+
+        - ブラウザを起動せずにAPIのみで下書き作成
+        - YouTube URLがfigure要素に変換される
+        - embedded-service="youtube"属性が設定される
+        """
+        # Arrange
+        youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        body = f"""This is a test article with YouTube embed.
+
+{youtube_url}
+
+The video should appear above."""
+
+        # Act
+        result = await note_create_draft.fn(
+            title="[E2E-TEST] YouTube Embed via API",
+            body=body,
+            tags=["e2e-test", "embed-api"],
+        )
+
+        # Assert - API response
+        assert "下書きを作成しました" in result
+        assert "ID:" in result
+
+        # Extract article ID and verify content
+        article_id = extract_article_id(result)
+        article_content = await note_get_article.fn(article_id)
+
+        # Verify embed figure is present
+        assert 'embedded-service="youtube"' in article_content
+        assert f'data-src="{youtube_url}"' in article_content
+        assert "embedded-content-key=" in article_content
+
+    async def test_twitter_embed_via_api(
+        self,
+        real_session: Session,
+    ) -> None:
+        """Twitter URLがAPIでfigure要素に変換される.
+
+        - Twitter status URLがfigure要素に変換される
+        - embedded-service="twitter"属性が設定される
+        """
+        # Arrange
+        twitter_url = "https://twitter.com/anthropaborean/status/1876108600584237308"
+        body = f"""This is a test article with Twitter embed.
+
+{twitter_url}
+
+The tweet should appear above."""
+
+        # Act
+        result = await note_create_draft.fn(
+            title="[E2E-TEST] Twitter Embed via API",
+            body=body,
+            tags=["e2e-test", "embed-api"],
+        )
+
+        # Assert - API response
+        assert "下書きを作成しました" in result
+
+        # Extract article ID and verify content
+        article_id = extract_article_id(result)
+        article_content = await note_get_article.fn(article_id)
+
+        # Verify embed figure is present
+        assert 'embedded-service="twitter"' in article_content
+        assert f'data-src="{twitter_url}"' in article_content
+
+    async def test_x_embed_via_api(
+        self,
+        real_session: Session,
+    ) -> None:
+        """X (Twitter rebrand) URLがAPIでfigure要素に変換される.
+
+        - x.com URLがfigure要素に変換される
+        - embedded-service="twitter"属性が設定される
+        """
+        # Arrange
+        x_url = "https://x.com/anthropaborean/status/1876108600584237308"
+        body = f"""This is a test article with X embed.
+
+{x_url}
+
+The post should appear above."""
+
+        # Act
+        result = await note_create_draft.fn(
+            title="[E2E-TEST] X Embed via API",
+            body=body,
+            tags=["e2e-test", "embed-api"],
+        )
+
+        # Assert - API response
+        assert "下書きを作成しました" in result
+
+        # Extract article ID and verify content
+        article_id = extract_article_id(result)
+        article_content = await note_get_article.fn(article_id)
+
+        # Verify embed figure is present (X URLs use twitter service)
+        assert 'embedded-service="twitter"' in article_content
+        assert f'data-src="{x_url}"' in article_content
+
+    async def test_note_embed_via_api(
+        self,
+        real_session: Session,
+    ) -> None:
+        """note.com記事URLがAPIでfigure要素に変換される.
+
+        - note.com記事URLがfigure要素に変換される
+        - embedded-service="note"属性が設定される
+        """
+        # Arrange - Use a public note.com article
+        note_url = "https://note.com/note_official/n/n0e7b8b4f5f3a"
+        body = f"""This is a test article with note.com embed.
+
+{note_url}
+
+The article card should appear above."""
+
+        # Act
+        result = await note_create_draft.fn(
+            title="[E2E-TEST] Note Embed via API",
+            body=body,
+            tags=["e2e-test", "embed-api"],
+        )
+
+        # Assert - API response
+        assert "下書きを作成しました" in result
+
+        # Extract article ID and verify content
+        article_id = extract_article_id(result)
+        article_content = await note_get_article.fn(article_id)
+
+        # Verify embed figure is present
+        assert 'embedded-service="note"' in article_content
+        assert f'data-src="{note_url}"' in article_content
+
+    async def test_multiple_embeds_via_api(
+        self,
+        real_session: Session,
+    ) -> None:
+        """複数の埋め込みURLがAPIで変換される.
+
+        - YouTube, Twitter両方のURLがfigure要素に変換される
+        """
+        # Arrange
+        youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        twitter_url = "https://twitter.com/anthropaborean/status/1876108600584237308"
+        body = f"""This article has multiple embeds.
+
+{youtube_url}
+
+Some text between embeds.
+
+{twitter_url}
+
+Both should appear as embed cards."""
+
+        # Act
+        result = await note_create_draft.fn(
+            title="[E2E-TEST] Multiple Embeds via API",
+            body=body,
+            tags=["e2e-test", "embed-api"],
+        )
+
+        # Assert - API response
+        assert "下書きを作成しました" in result
+
+        # Extract article ID and verify content
+        article_id = extract_article_id(result)
+        article_content = await note_get_article.fn(article_id)
+
+        # Verify both embeds are present
+        assert 'embedded-service="youtube"' in article_content
+        assert 'embedded-service="twitter"' in article_content
+        assert article_content.count('embedded-service="') >= 2
+
+    async def test_embed_in_paragraph_not_converted(
+        self,
+        real_session: Session,
+    ) -> None:
+        """テキストに埋め込まれたURLは変換されない.
+
+        - 段落内のURLはリンクのまま保持される
+        - スタンドアロンURLのみfigureに変換される
+        """
+        # Arrange
+        youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        body = f"""Check out this video: {youtube_url} which is great."""
+
+        # Act
+        result = await note_create_draft.fn(
+            title="[E2E-TEST] Embed in Paragraph",
+            body=body,
+            tags=["e2e-test", "embed-api"],
+        )
+
+        # Assert - API response
+        assert "下書きを作成しました" in result
+
+        # Extract article ID and verify content
+        article_id = extract_article_id(result)
+        article_content = await note_get_article.fn(article_id)
+
+        # URL should remain as link, not figure
+        assert 'embedded-service="youtube"' not in article_content
+        # URL should be in an anchor tag
+        assert f'href="{youtube_url}"' in article_content
+
+    async def test_embed_as_markdown_link_not_converted(
+        self,
+        real_session: Session,
+    ) -> None:
+        """Markdownリンク形式のURLは変換されない.
+
+        - [text](url)形式はアンカータグに変換される
+        - figure要素には変換されない
+        """
+        # Arrange
+        youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        body = f"""Here's a link: [Watch this video]({youtube_url})"""
+
+        # Act
+        result = await note_create_draft.fn(
+            title="[E2E-TEST] Embed as Link",
+            body=body,
+            tags=["e2e-test", "embed-api"],
+        )
+
+        # Assert - API response
+        assert "下書きを作成しました" in result
+
+        # Extract article ID and verify content
+        article_id = extract_article_id(result)
+        article_content = await note_get_article.fn(article_id)
+
+        # URL should be in anchor tag, not figure
+        assert 'embedded-service="youtube"' not in article_content
+        assert "Watch this video" in article_content
+
+
+class TestEmbedPreviewRendering:
+    """Test embed rendering in preview (requires browser)."""
+
+    async def test_youtube_embed_renders_in_preview(
+        self,
+        real_session: Session,
+    ) -> None:
+        """YouTubeの埋め込みがプレビューで正しくレンダリングされる.
+
+        - figure要素がiframeに変換される
+        - 埋め込みカードが表示される
+        """
+        # Arrange
+        youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        body = f"""Test embed preview.
+
+{youtube_url}
+"""
+
+        # Act
+        result = await note_create_draft.fn(
+            title="[E2E-TEST] YouTube Embed Preview",
+            body=body,
+            tags=["e2e-test", "embed-api"],
+        )
+
+        # Assert - API response
+        assert "下書きを作成しました" in result
+        article_id = extract_article_id(result)
+
+        # Verify preview rendering
+        async with preview_page_context(real_session, article_id) as page:
+            # Wait for embed to render (note.com renders iframes client-side)
+            embed_figure = page.locator('figure[embedded-service="youtube"]')
+            await embed_figure.wait_for(timeout=10000)
+
+            # Verify figure has correct attributes
+            assert await embed_figure.count() >= 1
+
+            # Note: iframe may or may not be present depending on client-side JS
+            # The figure element presence is sufficient to verify API conversion worked

--- a/tests/unit/test_embeds.py
+++ b/tests/unit/test_embeds.py
@@ -1,0 +1,225 @@
+"""Unit tests for embed API functions.
+
+Tests for api/embeds.py module which provides embed URL detection,
+service identification, and HTML generation for note.com embeds.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+
+
+class TestGetEmbedService:
+    """Tests for get_embed_service function."""
+
+    def test_youtube_watch_url(self) -> None:
+        """Test YouTube watch URL detection."""
+        from note_mcp.api.embeds import get_embed_service
+
+        assert get_embed_service("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == "youtube"
+        assert get_embed_service("https://youtube.com/watch?v=dQw4w9WgXcQ") == "youtube"
+        assert get_embed_service("http://www.youtube.com/watch?v=dQw4w9WgXcQ") == "youtube"
+
+    def test_youtube_short_url(self) -> None:
+        """Test YouTube short URL (youtu.be) detection."""
+        from note_mcp.api.embeds import get_embed_service
+
+        assert get_embed_service("https://youtu.be/dQw4w9WgXcQ") == "youtube"
+        assert get_embed_service("http://youtu.be/dQw4w9WgXcQ") == "youtube"
+
+    def test_twitter_url(self) -> None:
+        """Test Twitter URL detection."""
+        from note_mcp.api.embeds import get_embed_service
+
+        assert get_embed_service("https://twitter.com/user/status/1234567890") == "twitter"
+        assert get_embed_service("https://www.twitter.com/user/status/1234567890") == "twitter"
+
+    def test_x_url(self) -> None:
+        """Test X (Twitter rebrand) URL detection."""
+        from note_mcp.api.embeds import get_embed_service
+
+        assert get_embed_service("https://x.com/user/status/1234567890") == "twitter"
+        assert get_embed_service("https://www.x.com/user/status/1234567890") == "twitter"
+
+    def test_note_url(self) -> None:
+        """Test note.com article URL detection."""
+        from note_mcp.api.embeds import get_embed_service
+
+        assert get_embed_service("https://note.com/username/n/n1234567890ab") == "note"
+        assert get_embed_service("http://note.com/username/n/n1234567890ab") == "note"
+
+    def test_unsupported_url_returns_none(self) -> None:
+        """Test that unsupported URLs return None."""
+        from note_mcp.api.embeds import get_embed_service
+
+        assert get_embed_service("https://example.com") is None
+        assert get_embed_service("https://google.com") is None
+        assert get_embed_service("https://vimeo.com/123456") is None
+        assert get_embed_service("not a url") is None
+
+
+class TestIsEmbedUrl:
+    """Tests for is_embed_url function."""
+
+    def test_youtube_urls_are_embed_urls(self) -> None:
+        """Test that YouTube URLs are recognized as embed URLs."""
+        from note_mcp.api.embeds import is_embed_url
+
+        assert is_embed_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") is True
+        assert is_embed_url("https://youtu.be/dQw4w9WgXcQ") is True
+
+    def test_twitter_urls_are_embed_urls(self) -> None:
+        """Test that Twitter/X URLs are recognized as embed URLs."""
+        from note_mcp.api.embeds import is_embed_url
+
+        assert is_embed_url("https://twitter.com/user/status/1234567890") is True
+        assert is_embed_url("https://x.com/user/status/1234567890") is True
+
+    def test_note_urls_are_embed_urls(self) -> None:
+        """Test that note.com article URLs are recognized as embed URLs."""
+        from note_mcp.api.embeds import is_embed_url
+
+        assert is_embed_url("https://note.com/username/n/n1234567890ab") is True
+
+    def test_unsupported_urls_are_not_embed_urls(self) -> None:
+        """Test that unsupported URLs are not recognized as embed URLs."""
+        from note_mcp.api.embeds import is_embed_url
+
+        assert is_embed_url("https://example.com") is False
+        assert is_embed_url("https://google.com") is False
+        assert is_embed_url("not a url") is False
+
+
+class TestGenerateEmbedHtml:
+    """Tests for generate_embed_html function."""
+
+    def test_youtube_embed_structure(self) -> None:
+        """Test YouTube embed HTML structure."""
+        from note_mcp.api.embeds import generate_embed_html
+
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        html = generate_embed_html(url)
+
+        # Verify required attributes
+        assert "<figure" in html
+        assert 'data-src="https://www.youtube.com/watch?v=dQw4w9WgXcQ"' in html
+        assert 'embedded-service="youtube"' in html
+        assert 'contenteditable="false"' in html
+        assert "embedded-content-key=" in html
+        assert "</figure>" in html
+
+    def test_twitter_embed_structure(self) -> None:
+        """Test Twitter embed HTML structure."""
+        from note_mcp.api.embeds import generate_embed_html
+
+        url = "https://twitter.com/user/status/1234567890"
+        html = generate_embed_html(url, service="twitter")
+
+        assert 'embedded-service="twitter"' in html
+        assert f'data-src="{url}"' in html
+
+    def test_note_embed_structure(self) -> None:
+        """Test note.com embed HTML structure."""
+        from note_mcp.api.embeds import generate_embed_html
+
+        url = "https://note.com/username/n/n1234567890ab"
+        html = generate_embed_html(url, service="note")
+
+        assert 'embedded-service="note"' in html
+        assert f'data-src="{url}"' in html
+
+    def test_embed_key_format(self) -> None:
+        """Test that embed content key has correct format (emb + 13 hex chars)."""
+        from note_mcp.api.embeds import generate_embed_html
+
+        html = generate_embed_html("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+
+        # Extract embedded-content-key value
+        match = re.search(r'embedded-content-key="(emb[a-f0-9]+)"', html)
+        assert match is not None
+        key = match.group(1)
+        assert key.startswith("emb")
+        assert len(key) == 16  # "emb" + 13 chars
+
+    def test_uuid_attributes(self) -> None:
+        """Test that name and id attributes are valid UUIDs."""
+        from note_mcp.api.embeds import generate_embed_html
+
+        html = generate_embed_html("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+
+        # Extract name/id values
+        name_match = re.search(r'name="([^"]+)"', html)
+        id_match = re.search(r'id="([^"]+)"', html)
+
+        assert name_match is not None
+        assert id_match is not None
+
+        # Verify they are valid UUIDs
+        name_uuid = uuid.UUID(name_match.group(1))
+        id_uuid = uuid.UUID(id_match.group(1))
+
+        assert name_uuid == id_uuid  # Should be the same
+
+    def test_auto_detect_service(self) -> None:
+        """Test that service is auto-detected when not provided."""
+        from note_mcp.api.embeds import generate_embed_html
+
+        # YouTube
+        html = generate_embed_html("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+        assert 'embedded-service="youtube"' in html
+
+        # Twitter
+        html = generate_embed_html("https://twitter.com/user/status/123")
+        assert 'embedded-service="twitter"' in html
+
+        # note.com
+        html = generate_embed_html("https://note.com/user/n/n123")
+        assert 'embedded-service="note"' in html
+
+    def test_url_escaping(self) -> None:
+        """Test that special characters in URL are properly escaped."""
+        from note_mcp.api.embeds import generate_embed_html
+
+        url = 'https://www.youtube.com/watch?v=test&feature=share"<script>'
+        html = generate_embed_html(url, service="youtube")
+
+        # HTML special characters should be escaped
+        assert "&amp;" in html or "feature=share" in html
+        assert '"<script>' not in html  # Should be escaped
+
+    def test_unsupported_url_raises_error(self) -> None:
+        """Test that unsupported URL raises ValueError."""
+        from note_mcp.api.embeds import generate_embed_html
+
+        with pytest.raises(ValueError, match="Unsupported embed URL"):
+            generate_embed_html("https://example.com")
+
+
+class TestEmbedPatterns:
+    """Tests for embed URL pattern constants."""
+
+    def test_youtube_pattern_exports(self) -> None:
+        """Test that YOUTUBE_PATTERN is exported."""
+        from note_mcp.api.embeds import YOUTUBE_PATTERN
+
+        assert YOUTUBE_PATTERN.match("https://www.youtube.com/watch?v=abc123")
+        assert YOUTUBE_PATTERN.match("https://youtu.be/abc123")
+        assert not YOUTUBE_PATTERN.match("https://youtube.com/channel/abc")
+
+    def test_twitter_pattern_exports(self) -> None:
+        """Test that TWITTER_PATTERN is exported."""
+        from note_mcp.api.embeds import TWITTER_PATTERN
+
+        assert TWITTER_PATTERN.match("https://twitter.com/user/status/123")
+        assert TWITTER_PATTERN.match("https://x.com/user/status/123")
+        assert not TWITTER_PATTERN.match("https://twitter.com/user")
+
+    def test_note_pattern_exports(self) -> None:
+        """Test that NOTE_PATTERN is exported."""
+        from note_mcp.api.embeds import NOTE_PATTERN
+
+        assert NOTE_PATTERN.match("https://note.com/user/n/nabc123")
+        assert not NOTE_PATTERN.match("https://note.com/user")

--- a/tests/unit/test_insert_embed.py
+++ b/tests/unit/test_insert_embed.py
@@ -10,10 +10,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from playwright.async_api import Error as PlaywrightError
 
-from note_mcp.browser.insert_embed import (
+from note_mcp.api.embeds import (
     NOTE_PATTERN,
     TWITTER_PATTERN,
     YOUTUBE_PATTERN,
+)
+from note_mcp.browser.insert_embed import (
     EmbedResult,
     _wait_for_embed_insertion,
     get_embed_service,

--- a/tests/unit/test_typing_helpers.py
+++ b/tests/unit/test_typing_helpers.py
@@ -4,6 +4,15 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from note_mcp.api.embeds import (
+    NOTE_PATTERN as _EMBED_NOTE_PATTERN,
+)
+from note_mcp.api.embeds import (
+    TWITTER_PATTERN as _EMBED_TWITTER_PATTERN,
+)
+from note_mcp.api.embeds import (
+    YOUTUBE_PATTERN as _EMBED_YOUTUBE_PATTERN,
+)
 from note_mcp.browser.typing_helpers import (
     _ALIGN_CENTER_PATTERN,
     _ALIGN_CENTER_PLACEHOLDER,
@@ -17,11 +26,8 @@ from note_mcp.browser.typing_helpers import (
     _CITATION_PATTERN,
     _CITATION_URL_PATTERN,
     _CODE_FENCE_PATTERN,
-    _EMBED_NOTE_PATTERN,
     _EMBED_PLACEHOLDER_END,
     _EMBED_PLACEHOLDER_START,
-    _EMBED_TWITTER_PATTERN,
-    _EMBED_YOUTUBE_PATTERN,
     _HEADING_PATTERN,
     _ORDERED_LIST_PATTERN,
     _STRIKETHROUGH_PATTERN,


### PR DESCRIPTION
## Summary

- ブラウザ自動化からAPI経由での埋め込み処理に変更し、DRY原則を適用
- 新規モジュール `api/embeds.py` に埋め込みパターン定義と生成関数を集約
- エディター自動保存による埋め込みHTML破損問題を回避

## Test plan

- [ ] `uv run pytest tests/unit/test_embeds.py -v` でユニットテスト確認
- [ ] `uv run pytest tests/unit/test_markdown_to_html.py::TestEmbedUrlConversion -v` で変換テスト確認
- [ ] `uv run pytest tests/e2e/test_embed_api.py -v` でE2Eテスト確認
- [ ] 埋め込みURL（YouTube、Twitter、note.com）を含む記事の作成・更新が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)