### PR TITLE
refactor(#123): remove unused has_math_formula() function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,29 @@ docker compose up --build
 
 開発原則の詳細は **Constitution** を参照してください。以下は主要な原則の概要です：
 
+### Issue Workflow
+
+issue対応の指示を受けた場合は、作業開始前に適切なブランチに切り替えること。
+
+**ブランチ命名規則:**
+- 機能追加: `feat/<issue番号>-<説明>`
+- バグ修正: `fix/<issue番号>-<説明>`
+- リファクタリング: `refactor/<issue番号>-<説明>`
+- ドキュメント: `docs/<issue番号>-<説明>`
+
+**例:**
+```bash
+# Issue #123 の機能追加
+git checkout -b feat/123-add-user-authentication
+
+# Issue #456 のバグ修正
+git checkout -b fix/456-fix-login-error
+```
+
+**注意:**
+- 既存のブランチがある場合はそちらを使用
+- `<説明>`は英語で、ハイフン区切りの短い説明（2-4語）
+
 ### Test-Driven Development (Article 1)
 
 1. ユニットテストを先に作成
@@ -292,6 +315,7 @@ docker compose up --build
 
 ## Recent Changes
 
+- 2026-01-13: Added Issue Workflow section with branch naming conventions
 - 2025-12-31: Added Available Skills section with api-investigator導線
 - 001-note-mcp: Added Python 3.11+
 - 2025-12-20: Updated CLAUDE.md based on Constitution v1.0.0

--- a/src/note_mcp/utils/markdown_to_html.py
+++ b/src/note_mcp/utils/markdown_to_html.py
@@ -74,28 +74,6 @@ _TEXT_ALIGN_LEFT_PATTERN = re.compile(r"^<-(.+)$", re.MULTILINE)
 # Pattern to find URLs that are alone on a line (potential embed URLs)
 _STANDALONE_URL_PATTERN = re.compile(r"^(https?://\S+)$", re.MULTILINE)
 
-# Math formula patterns (Issue #101)
-# Must match patterns in typing_helpers.py:
-# - Inline math: $${formula}$$ (double dollar signs WITH curly braces)
-# - Display math: $$formula$$ (double dollar signs WITHOUT curly braces)
-_MATH_INLINE_PATTERN = re.compile(r"\$\$\{.+?\}\$\$", re.DOTALL)
-_MATH_DISPLAY_PATTERN = re.compile(r"\$\$[^{].*?\$\$", re.DOTALL)
-
-
-def has_math_formula(content: str) -> bool:
-    """Check if content contains math formulas that require browser automation.
-
-    Detects inline math ($${formula}$$) and display math ($$formula$$) patterns
-    that need to be processed via ProseMirror editor to render as KaTeX.
-
-    Args:
-        content: Markdown content to check.
-
-    Returns:
-        True if content contains math formulas.
-    """
-    return bool(_MATH_INLINE_PATTERN.search(content) or _MATH_DISPLAY_PATTERN.search(content))
-
 
 def has_ruby_notation(content: str) -> bool:
     """Check if content contains ruby notation that requires browser automation.

--- a/tests/unit/test_markdown_to_html.py
+++ b/tests/unit/test_markdown_to_html.py
@@ -1,6 +1,6 @@
 """Unit tests for Markdown conversion utility."""
 
-from note_mcp.utils.markdown_to_html import has_math_formula, has_ruby_notation, markdown_to_html
+from note_mcp.utils.markdown_to_html import has_ruby_notation, markdown_to_html
 
 
 class TestMarkdownToHtml:
@@ -681,67 +681,6 @@ print(formula)
         assert result.count("text-align: center") == 1
         assert result.count("text-align: right") == 1
         assert result.count("text-align: left") == 1
-
-
-class TestHasMathFormula:
-    """Tests for has_math_formula function.
-
-    Issue #107 PR review comment: Add unit tests for has_math_formula()
-    to ensure math detection works correctly.
-
-    note.com uses double-dollar-sign patterns:
-    - Inline math: $${formula}$$ (with curly braces)
-    - Display math: $$formula$$ (without curly braces)
-    """
-
-    def test_inline_math_detected(self) -> None:
-        """Test that inline math $${formula}$$ is detected."""
-        assert has_math_formula("$${E = mc^2}$$") is True
-
-    def test_display_math_detected(self) -> None:
-        """Test that display math $$formula$$ is detected."""
-        assert has_math_formula("$$x = \\frac{-b}{2a}$$") is True
-
-    def test_normal_text_not_detected(self) -> None:
-        """Test that normal text without math is not detected."""
-        assert has_math_formula("通常のテキスト") is False
-
-    def test_currency_symbol_not_detected(self) -> None:
-        """Test that currency symbol $100 is not detected as math."""
-        assert has_math_formula("$100") is False
-
-    def test_inline_math_complex_formula(self) -> None:
-        """Test complex inline math formula detection."""
-        assert has_math_formula("$${\\alpha + \\beta = \\gamma}$$") is True
-
-    def test_display_math_quadratic(self) -> None:
-        """Test quadratic formula in display math."""
-        assert has_math_formula("$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$") is True
-
-    def test_math_in_sentence(self) -> None:
-        """Test math embedded in Japanese sentence."""
-        assert has_math_formula("アインシュタインの公式は$${E = mc^2}$$です。") is True
-
-    def test_multiple_dollar_signs_no_braces(self) -> None:
-        """Test multiple single dollar signs (not math)."""
-        assert has_math_formula("The price is $50 or $100") is False
-
-    def test_empty_string(self) -> None:
-        """Test empty string returns False."""
-        assert has_math_formula("") is False
-
-    def test_only_braces_no_dollar(self) -> None:
-        """Test braces without dollar sign (not math)."""
-        assert has_math_formula("{formula}") is False
-
-    def test_single_dollar_not_detected(self) -> None:
-        """Test that single dollar sign pattern is not detected as math."""
-        assert has_math_formula("${E = mc^2}$") is False
-
-    def test_double_dollar_required(self) -> None:
-        """Test that double dollar signs are required for math detection."""
-        assert has_math_formula("$formula$") is False
-        assert has_math_formula("$$formula$$") is True
 
 
 class TestHasRubyNotation:


### PR DESCRIPTION
## Summary
- Remove `has_math_formula()` function and related pattern constants that became unused after PR #119 made math formulas API-compatible
- Remove `_MATH_INLINE_PATTERN` and `_MATH_DISPLAY_PATTERN` constants from `markdown_to_html.py`
- Remove `TestHasMathFormula` test class (12 tests) from `test_markdown_to_html.py`
- Add Issue Workflow section to CLAUDE.md with branch naming conventions

## Test plan
- [x] `uv run ruff check --fix .` passes
- [x] `uv run ruff format .` passes
- [x] `uv run mypy .` passes (no issues found)
- [x] `uv run pytest tests/unit/` passes (713 tests)
- [x] Verify `grep -r "has_math_formula" src/` returns no results

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)