### PR TITLE
refactor(#134): E2Eプレビューアクセスをエディタ経由からAPI経由に変更

### DIFF
--- a/src/note_mcp/api/articles.py
+++ b/src/note_mcp/api/articles.py
@@ -589,7 +589,11 @@ async def get_preview_access_token(
     if not token:
         raise NoteAPIError(
             code=ErrorCode.API_ERROR,
-            message="Failed to get preview access token",
+            message=(
+                "Failed to get preview access token. "
+                "Possible causes: article does not exist, article is already published, "
+                "or insufficient permissions."
+            ),
             details={"article_key": article_key, "response": response},
         )
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -176,9 +176,7 @@ async def _inject_session_cookies(page: Page, session: Session) -> None:
     await page.context.add_cookies(playwright_cookies)
 
 
-async def _open_preview_and_get_page(
-    page: Page, session: Session, article_key: str
-) -> Page:
+async def _open_preview_and_get_page(page: Page, session: Session, article_key: str) -> Page:
     """Navigate directly to preview URL using API-based access.
 
     Uses the access_tokens API to get a preview token, then navigates

--- a/tests/e2e/helpers/preview_helpers.py
+++ b/tests/e2e/helpers/preview_helpers.py
@@ -60,10 +60,13 @@ async def open_preview_via_api(
         TimeoutError: If navigation times out
     """
     # Get preview access token via API
+    logger.debug("Fetching preview access token for article: %s", article_key)
     token = await get_preview_access_token(session, article_key)
+    logger.debug("Successfully obtained preview token")
 
     # Build direct preview URL
     preview_url = build_preview_url(article_key, token)
+    logger.debug("Navigating to preview URL: %s", preview_url)
 
     # Navigate directly to preview URL
     await page.goto(
@@ -73,6 +76,7 @@ async def open_preview_via_api(
     )
     # Wait for JavaScript rendering (needed for math formulas like nwc-formula)
     await page.wait_for_load_state("networkidle", timeout=timeout)
+    logger.debug("Preview page loaded successfully for article: %s", article_key)
 
     return page
 

--- a/tests/unit/test_preview_access.py
+++ b/tests/unit/test_preview_access.py
@@ -21,17 +21,13 @@ class TestGetPreviewAccessToken:
         )
 
     @pytest.mark.asyncio
-    async def test_get_preview_access_token_success(
-        self, mock_session: Session
-    ) -> None:
+    async def test_get_preview_access_token_success(self, mock_session: Session) -> None:
         """Normal case: successfully get preview_access_token."""
         from note_mcp.api.articles import get_preview_access_token
 
-        mock_response = {"data": {"preview_access_token": "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"}}
+        mock_response = {"data": {"preview_access_token": "a1b2c3d4e5f607081920304050600a0b"}}
 
-        with patch(
-            "note_mcp.api.articles.NoteAPIClient"
-        ) as mock_client_class:
+        with patch("note_mcp.api.articles.NoteAPIClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post.return_value = mock_response
             mock_client.__aenter__.return_value = mock_client
@@ -40,16 +36,14 @@ class TestGetPreviewAccessToken:
 
             token = await get_preview_access_token(mock_session, "n1234567890ab")
 
-            assert token == "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+            assert token == "a1b2c3d4e5f607081920304050600a0b"
             mock_client.post.assert_called_once_with(
                 "/v2/notes/n1234567890ab/access_tokens",
                 json={"key": "n1234567890ab"},
             )
 
     @pytest.mark.asyncio
-    async def test_get_preview_access_token_returns_32_char_hex(
-        self, mock_session: Session
-    ) -> None:
+    async def test_get_preview_access_token_returns_32_char_hex(self, mock_session: Session) -> None:
         """preview_access_token should be 32-character hex string."""
         from note_mcp.api.articles import get_preview_access_token
 
@@ -57,9 +51,7 @@ class TestGetPreviewAccessToken:
         hex_token = "ec416231ef6b60f12e830f37144432b3"
         mock_response = {"data": {"preview_access_token": hex_token}}
 
-        with patch(
-            "note_mcp.api.articles.NoteAPIClient"
-        ) as mock_client_class:
+        with patch("note_mcp.api.articles.NoteAPIClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post.return_value = mock_response
             mock_client.__aenter__.return_value = mock_client
@@ -73,17 +65,13 @@ class TestGetPreviewAccessToken:
             assert all(c in "0123456789abcdef" for c in token)
 
     @pytest.mark.asyncio
-    async def test_get_preview_access_token_raises_on_empty_response(
-        self, mock_session: Session
-    ) -> None:
+    async def test_get_preview_access_token_raises_on_empty_response(self, mock_session: Session) -> None:
         """Should raise NoteAPIError when token is missing from response."""
         from note_mcp.api.articles import get_preview_access_token
 
         mock_response: dict[str, dict[str, str]] = {"data": {}}
 
-        with patch(
-            "note_mcp.api.articles.NoteAPIClient"
-        ) as mock_client_class:
+        with patch("note_mcp.api.articles.NoteAPIClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post.return_value = mock_response
             mock_client.__aenter__.return_value = mock_client
@@ -94,6 +82,31 @@ class TestGetPreviewAccessToken:
                 await get_preview_access_token(mock_session, "n1234567890ab")
 
             assert exc_info.value.code == ErrorCode.API_ERROR
+
+    @pytest.mark.asyncio
+    async def test_get_preview_access_token_propagates_api_errors(self, mock_session: Session) -> None:
+        """Should propagate NoteAPIError from API client (e.g., 401, 404)."""
+        from note_mcp.api.articles import get_preview_access_token
+
+        api_error = NoteAPIError(
+            code=ErrorCode.NOT_AUTHENTICATED,
+            message="Unauthorized",
+            details={"status_code": 401},
+        )
+
+        with patch("note_mcp.api.articles.NoteAPIClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = api_error
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(NoteAPIError) as exc_info:
+                await get_preview_access_token(mock_session, "n1234567890ab")
+
+            # Verify the original API error is propagated, not wrapped
+            assert exc_info.value.code == ErrorCode.NOT_AUTHENTICATED
+            assert exc_info.value.message == "Unauthorized"
 
 
 class TestBuildPreviewUrl:


### PR DESCRIPTION
## Summary

- E2Eテストのプレビューアクセスを、複雑なエディタUI操作からAPI経由の直接アクセスに変更
- `get_preview_access_token()`: access_tokens APIでプレビュートークンを取得
- `build_preview_url()`: プレビューURLを構築
- `open_preview_via_api()`: API経由でプレビューページを開く新関数
- `open_preview_for_article_key()`: deprecation warning追加（後方互換性のため保持）

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `src/note_mcp/api/articles.py` | `get_preview_access_token()`, `build_preview_url()` 追加 |
| `tests/unit/test_preview_access.py` | 新規ユニットテスト（5件） |
| `tests/e2e/helpers/preview_helpers.py` | API経由のプレビューアクセス実装 |
| `tests/e2e/conftest.py` | `preview_page` fixture更新 |

## プレビューURL形式

```
https://note.com/preview/{article_key}?prev_access_key={token}
```

## Test plan

- [x] ユニットテスト: 5件パス
- [x] E2Eプレビューテスト: 4件パス

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)