### PR TITLE
feat: add /start-issue command and enhance Issue Workflow documentation

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -119,7 +119,7 @@ git checkout <existing-branch>
 
 ### Step 6: 実装計画の立案
 
-EnterPlanModeを使用してプランモードに移行し、以下の情報を基に実装計画を立てる:
+プランモードに移行し、以下の情報を基に実装計画を立てる:
 
 **計画に含める内容**:
 1. issueの要件サマリー
@@ -151,30 +151,9 @@ EnterPlanModeを使用してプランモードに移行し、以下の情報を�
 
 ### Step 7: 計画のissueへの記録
 
-issue-reporterスキルに従い、立案した計画をissueにコメントとして投稿:
+issue-reporterスキルの「計画立案時（Plan）」形式に従い、立案した計画をissueにコメントとして投稿する。
 
-```bash
-gh issue comment $ARGUMENTS --body "$(cat <<'EOF'
-## 📋 実装計画
-
-**作業内容**: [issueタイトル]
-
-### 計画
-
-1. [ステップ1]
-2. [ステップ2]
-3. [ステップ3]
-
-### 予想される課題
-
-- [課題1]
-- [課題2]
-
----
-*Posted by Claude Code at YYYY-MM-DD HH:MM*
-EOF
-)"
-```
+詳細: `.claude/skills/issue-reporter/SKILL.md`
 
 ## Error Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ issue対応時は以下のワークフローに従う。
 |------|---------|--------------|
 | 1 | issueを作成 | GitHub上で手動作成 |
 | 2 | issueを読み込み、ブランチ作成、計画立案 | `/start-issue <issue番号>` |
-| 3 | 計画承認後、実装 | 手動実装 |
+| 3 | 計画承認後、TDDワークフローに従って実装 | TDD実装 |
 | 4 | PR作成 | `/commit-commands:commit-push-pr` |
 | 5 | PRレビュー | `/pr-review-toolkit:review-pr` |
 | 6 | レビューコメント対応 | `/review-pr-comments` |
@@ -218,6 +218,8 @@ issue対応時は以下のワークフローに従う。
 | バグ修正 | `fix/` | `fix/456-fix-login-error` |
 | リファクタリング | `refactor/` | `refactor/789-cleanup-api` |
 | ドキュメント | `docs/` | `docs/101-update-readme` |
+| テスト | `test/` | `test/111-add-e2e-tests` |
+| 雑務 | `chore/` | `chore/222-update-dependencies` |
 
 **注意:**
 - 既存のブランチがある場合はそちらを使用


### PR DESCRIPTION
## Summary

- Add new `/start-issue` custom command that automates issue workflow steps 2-4 (read issue, create branch, plan implementation)
- Enhance CLAUDE.md Issue Workflow section with standard workflow table and progress recording guidance
- Integrate issue-reporter skill for automatic progress posting to issues

## Test plan

- [ ] Run `/start-issue <issue-number>` with an existing issue
- [ ] Verify branch is created with correct naming convention
- [ ] Verify plan mode is entered
- [ ] Verify plan is posted to issue as comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)