### PR TITLE
fix(#161): extract_article_key()の正規表現を修正

### DIFF
--- a/tests/e2e/helpers/article_helpers.py
+++ b/tests/e2e/helpers/article_helpers.py
@@ -10,14 +10,15 @@ import re
 
 
 def extract_article_key(result: str) -> str:
-    """Extract article_key from note_create_from_file.fn() result.
+    """Extract article_key from MCP tool result.
 
     Parses the text output from MCP tools to find the article key,
     which is needed for preview page navigation.
 
     Args:
-        result: The text result from note_create_from_file.fn()
-            Expected format includes "記事キー: n1234567890ab"
+        result: The text result from MCP tools like note_create_draft.fn()
+            or note_create_from_file.fn()
+            Supported formats: "キー: n1234567890ab" or "記事キー: n1234567890ab"
 
     Returns:
         The extracted article key (e.g., "n1234567890ab")
@@ -26,11 +27,11 @@ def extract_article_key(result: str) -> str:
         ValueError: If article key cannot be found in the result
 
     Example:
-        >>> result = "✅ 下書きを作成しました\\n   タイトル: Test\\n   記事ID: 123\\n   記事キー: n1234567890ab"
+        >>> result = "下書きを作成しました。ID: 123、キー: n1234567890ab"
         >>> extract_article_key(result)
         'n1234567890ab'
     """
-    match = re.search(r"記事キー:\s*(\S+)", result)
+    match = re.search(r"(?:記事)?キー:\s*(\S+)", result)
     if not match:
         raise ValueError(f"Could not extract article key from result: {result}")
     return match.group(1)

--- a/tests/unit/test_article_helpers.py
+++ b/tests/unit/test_article_helpers.py
@@ -71,13 +71,15 @@ class TestExtractArticleKey:
         with pytest.raises(ValueError, match="Could not extract article key"):
             extract_article_key("No key here")
 
-    def test_extract_key_old_format_not_supported(self) -> None:
-        """Old format '、キー: n...' is not supported by current regex.
+    def test_extract_key_short_format(self) -> None:
+        """'キー: n...' format (without 記事 prefix) should be matched.
 
-        The current implementation only matches '記事キー:' format.
-        This test documents the limitation.
+        This format is used by note_create_draft and other MCP tools.
         """
         result = "下書きを作成しました。ID: 123456789、キー: n1234567890ab"
-        # Current regex uses 記事キー, so this will fail
-        with pytest.raises(ValueError, match="Could not extract article key"):
-            extract_article_key(result)
+        assert extract_article_key(result) == "n1234567890ab"
+
+    def test_extract_key_with_extra_whitespace(self) -> None:
+        """Key followed by multiple spaces should be handled."""
+        result = "キー:   n1234567890ab"
+        assert extract_article_key(result) == "n1234567890ab"


### PR DESCRIPTION
## Summary

- `extract_article_key()` の正規表現を修正し、サーバーレスポンスの両形式に対応
- 正規表現を `r"(?:記事)?キー:\s*(\S+)"` に変更
- 「キー:」形式と「記事キー:」形式の両方をサポート

## Test plan

- [x] ユニットテスト全11件パス (`uv run pytest tests/unit/test_article_helpers.py -v`)
- [x] コード品質チェックパス (`uv run ruff check --fix . && uv run ruff format . && uv run mypy .`)

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)