### PR TITLE
refactor(#177): Title抽出関数の正規表現パターンを共通定数化

### DIFF
--- a/src/note_mcp/utils/file_parser.py
+++ b/src/note_mcp/utils/file_parser.py
@@ -57,6 +57,10 @@ IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 # Patterns that indicate a URL (not a local file)
 URL_PREFIXES = ("http://", "https://", "data:")
 
+# Patterns to match H1 and H2 title headings
+_H1_TITLE_PATTERN = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+_H2_TITLE_PATTERN = re.compile(r"^##\s+(.+)$", re.MULTILINE)
+
 
 def parse_markdown_file(file_path: Path | str) -> ParsedArticle:
     """Parse a Markdown file and extract article components.
@@ -184,12 +188,12 @@ def _get_title(frontmatter: dict[str, Any], body: str) -> str | None:
         return str(frontmatter["title"]).strip()
 
     # Try H1 heading
-    h1_match = re.search(r"^#\s+(.+)$", body, re.MULTILINE)
+    h1_match = _H1_TITLE_PATTERN.search(body)
     if h1_match:
         return h1_match.group(1).strip()
 
     # Try H2 heading as fallback
-    h2_match = re.search(r"^##\s+(.+)$", body, re.MULTILINE)
+    h2_match = _H2_TITLE_PATTERN.search(body)
     if h2_match:
         return h2_match.group(1).strip()
 


### PR DESCRIPTION
## Summary

- `_get_title` 関数で使用していたH1/H2見出し検出の正規表現を共通定数として抽出
- `_H1_TITLE_PATTERN`, `_H2_TITLE_PATTERN` を追加し、DRY原則（Article 7）に準拠

Closes #177

## Test plan

- [x] 既存ユニットテスト全23件パス (`tests/unit/test_file_parser.py`)
- [x] 品質チェック（ruff, mypy）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)