### PR TITLE
refactor(#175): Code Block保護パターンをContext Manager化

### DIFF
--- a/src/note_mcp/utils/markdown_to_html.py
+++ b/src/note_mcp/utils/markdown_to_html.py
@@ -86,13 +86,15 @@ def _protect_code_blocks(content: str, prefix: str = "CODE_BLOCK") -> Iterator[t
         prefix: Prefix for placeholder names. Use unique prefixes to avoid conflicts.
 
     Yields:
-        Tuple of (protected_content, code_blocks_list) where code_blocks_list
-        contains (placeholder, original) tuples for restoration.
+        Tuple of (protected_content, code_blocks_list) where:
+        - protected_content: Content with code blocks replaced by placeholders
+        - code_blocks_list: List of (placeholder, original_code) tuples for restoration
 
     Example:
         with _protect_code_blocks(content, "ALIGN") as (protected, blocks):
-            result = some_processing(protected)
-        result = _restore_code_blocks(result, blocks)
+            # Process the protected content (reassign to protected)
+            protected = some_pattern.sub(replacement, protected)
+        return _restore_code_blocks(protected, blocks)
     """
     code_blocks: list[tuple[str, str]] = []
 


### PR DESCRIPTION
## Summary

- `_protect_code_blocks` コンテキストマネージャーと `_restore_code_blocks` 関数を追加
- `_convert_text_alignment` と `_convert_toc_to_placeholder` の重複コードを統合
- DRY原則（Constitution Article 7）に準拠し、約30行のコード削減を実現

## Test plan

- [x] 既存ユニットテスト（76件）がすべてパス
- [x] 全テスト（499件）がパス
- [x] ruff check/format パス
- [x] mypy 型チェック パス

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)