### PR TITLE
docs: upload_images=False時の挙動をdocstringに明記

### DIFF
--- a/src/note_mcp/server.py
+++ b/src/note_mcp/server.py
@@ -527,6 +527,7 @@ async def note_create_from_file(
     Args:
         file_path: Markdownファイルのパス
         upload_images: ローカル画像をアップロードするかどうか（デフォルト: True）
+            Falseの場合、ローカルパスがそのまま残り、プレビューで画像が表示されません。
 
     Returns:
         作成結果のメッセージ（記事IDを含む）


### PR DESCRIPTION
## Summary
- `note_create_from_file`の`upload_images`パラメータのdocstringを改善
- `False`指定時にローカル画像パスがそのまま残り、プレビューで画像が表示されないことを明記

## Test plan
- [ ] docstringの内容が正確であることを確認
- [ ] ruff check / mypy が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)