### PR TITLE
fix(#191): テストのDeprecationWarningとRuntimeWarningを修正

### DIFF
--- a/tests/contract/test_mcp_tools.py
+++ b/tests/contract/test_mcp_tools.py
@@ -13,7 +13,7 @@ from note_mcp.server import mcp
 
 def get_tools() -> dict[str, Any]:
     """Get all registered tools synchronously."""
-    return asyncio.get_event_loop().run_until_complete(mcp._tool_manager.get_tools())
+    return asyncio.run(mcp._tool_manager.get_tools())
 
 
 class TestMCPServerConfiguration:

--- a/tests/unit/test_browser_manager.py
+++ b/tests/unit/test_browser_manager.py
@@ -41,6 +41,7 @@ class TestBrowserManager:
             mock_browser = AsyncMock()
             mock_context = AsyncMock()
             mock_page = AsyncMock()
+            mock_page.is_closed = MagicMock(return_value=False)
 
             mock_pw = AsyncMock()
             mock_pw.chromium.launch = AsyncMock(return_value=mock_browser)


### PR DESCRIPTION
## Summary

- テスト実行時に発生していたDeprecationWarningとRuntimeWarningを修正
- `test_mcp_tools.py`: `asyncio.get_event_loop().run_until_complete()`を`asyncio.run()`に変更（Python 3.10+対応）
- `test_browser_manager.py`: `mock_page.is_closed`をMagicMockに設定し、未awaitコルーチン警告を解消

## Test plan

- [x] 対象テストファイルでwarningが発生しないことを確認
- [x] 全テスト（698件）がパスすることを確認
- [x] 品質チェック（ruff, mypy）がパスすることを確認

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)