### PR TITLE
fix: resolve TigerVNC startup failure and Python permission issues in Docker

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -96,6 +96,18 @@ start_vnc() {
 
     log_info "Starting TigerVNC server on port $port"
 
+    # Clean up any existing VNC processes from previous runs
+    # This prevents "port already in use" errors on rapid container restarts
+    pkill -x Xvnc 2>/dev/null || true
+    pkill -x websockify 2>/dev/null || true
+
+    # Remove stale X11 lock files
+    rm -f /tmp/.X${display_num}-lock 2>/dev/null || true
+    rm -f /tmp/.X11-unix/X${display_num} 2>/dev/null || true
+
+    # Brief delay to ensure port is released
+    sleep 0.5
+
     # Create VNC password file (empty password for no authentication)
     mkdir -p ~/.vnc
     echo "" | vncpasswd -f > ~/.vnc/passwd 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Add cleanup logic at start of `start_vnc()` to kill existing Xvnc/websockify processes and remove stale X11 lock files before starting new VNC server
- Set `UV_PYTHON_INSTALL_DIR=/opt/uv/python` to store Python in shared location accessible by all users
- Add `chmod -R a+rwX` to make uv-managed Python accessible to non-root users

## Test plan

- [ ] Run `docker compose down && docker compose up investigator` and verify VNC starts successfully
- [ ] Run `docker compose restart investigator` multiple times to verify rapid restart works
- [ ] Verify `uv run python --version` shows Python 3.13.x inside container
- [ ] Verify MCP server starts and responds on port 9000

🤖 Generated with [Claude Code](https://claude.com/claude-code)