### PR TITLE
fix(#220): correct noteマネー embed service name and US stock URL path

### DIFF
--- a/docs/features/embed.md
+++ b/docs/features/embed.md
@@ -127,7 +127,7 @@ noteマネー（money.note.com）の株価チャートを埋め込むことが�
 | 種類 | URLパターン | 例 |
 |------|------------|-----|
 | 日本株 | `https://money.note.com/companies/{証券コード}` | https://money.note.com/companies/5243 |
-| 米国株 | `https://money.note.com/us_companies/{ティッカー}` | https://money.note.com/us_companies/GOOG |
+| 米国株 | `https://money.note.com/us-companies/{ティッカー}` | https://money.note.com/us-companies/GOOG |
 | 指数 | `https://money.note.com/indices/{指数コード}` | https://money.note.com/indices/NKY |
 | 投資信託 | `https://money.note.com/investments/{ファンドコード}` | https://money.note.com/investments/0331418A |
 
@@ -146,7 +146,7 @@ note.comエディタと同様の記法も使用できます。記法は単独の
 | 記法 | 説明 | 変換先URL |
 |------|------|-----------|
 | `^{証券コード}` | 日本株（4-5桁） | `https://money.note.com/companies/{証券コード}` |
-| `${ティッカー}` | 米国株（大文字） | `https://money.note.com/us_companies/{ティッカー}` |
+| `${ティッカー}` | 米国株（大文字） | `https://money.note.com/us-companies/{ティッカー}` |
 
 ```markdown
 # 注目銘柄

--- a/src/note_mcp/api/embeds.py
+++ b/src/note_mcp/api/embeds.py
@@ -42,9 +42,9 @@ NOTE_PATTERN = re.compile(r"^https?://note\.com/\w+/n/\w+$")
 # GitHub Gist: gist.github.com/user/gist_id (with optional trailing slash and file fragment)
 GIST_PATTERN = re.compile(r"^https?://gist\.github\.com/[\w-]+/[\w]+/?(?:#[\w-]+)?$")
 
-# noteマネー (stock chart): money.note.com/companies|us_companies|indices|investments/xxx
+# noteマネー (stock chart): money.note.com/companies|us-companies|indices|investments/xxx
 # Supports Japanese stocks, US stocks, indices, and investment trusts
-MONEY_PATTERN = re.compile(r"^https?://money\.note\.com/(companies|us_companies|indices|investments)/[\w-]+/?$")
+MONEY_PATTERN = re.compile(r"^https?://money\.note\.com/(companies|us-companies|indices|investments)/[\w-]+/?$")
 
 
 def get_embed_service(url: str) -> str | None:
@@ -54,7 +54,7 @@ def get_embed_service(url: str) -> str | None:
         url: The URL to check.
 
     Returns:
-        Service type ('youtube', 'twitter', 'note', 'gist', 'money') or None if unsupported.
+        Service type ('youtube', 'twitter', 'note', 'gist', 'oembed') or None if unsupported.
     """
     if YOUTUBE_PATTERN.match(url):
         return "youtube"
@@ -65,7 +65,7 @@ def get_embed_service(url: str) -> str | None:
     if GIST_PATTERN.match(url):
         return "gist"
     if MONEY_PATTERN.match(url):
-        return "money"
+        return "oembed"
     return None
 
 
@@ -94,7 +94,7 @@ def _build_embed_figure_html(
     Args:
         url: Original URL (YouTube, Twitter, note.com, GitHub Gist, noteマネー).
         embed_key: Embed key (random for placeholder, server-registered for final).
-        service: Service type ('youtube', 'twitter', 'note', 'gist', 'money').
+        service: Service type ('youtube', 'twitter', 'note', 'gist', 'oembed').
 
     Returns:
         HTML figure element string.
@@ -126,7 +126,7 @@ def generate_embed_html(url: str, service: str | None = None) -> str:
 
     Args:
         url: Original URL (YouTube, Twitter, note.com, GitHub Gist, noteマネー).
-        service: Service type ('youtube', 'twitter', 'note', 'gist', 'money').
+        service: Service type ('youtube', 'twitter', 'note', 'gist', 'oembed').
                  If None, auto-detected from URL.
 
     Returns:
@@ -238,7 +238,7 @@ async def fetch_embed_key(
     if service == "note":
         return await _fetch_note_embed_key(session, url, article_key)
 
-    # YouTube/Twitter/Gist/Money: use existing /v2/embed_by_external_api endpoint
+    # YouTube/Twitter/Gist/noteマネー: use existing /v2/embed_by_external_api endpoint
     params = {
         "url": url,
         "service": service,
@@ -277,7 +277,7 @@ def generate_embed_html_with_key(
     Args:
         url: Original URL (YouTube, Twitter, note.com, GitHub Gist, noteマネー).
         embed_key: Server-registered embed key from fetch_embed_key().
-        service: Service type ('youtube', 'twitter', 'note', 'gist', 'money').
+        service: Service type ('youtube', 'twitter', 'note', 'gist', 'oembed').
                  If None, auto-detected from URL.
 
     Returns:

--- a/src/note_mcp/utils/markdown_to_html.py
+++ b/src/note_mcp/utils/markdown_to_html.py
@@ -309,7 +309,7 @@ def _convert_stock_notation(content: str) -> str:
 
     Converts stock notation markers BEFORE markdown conversion:
     - ^5243 (Japanese stock) → https://money.note.com/companies/5243
-    - $GOOG (US stock) → https://money.note.com/us_companies/GOOG
+    - $GOOG (US stock) → https://money.note.com/us-companies/GOOG
 
     Only converts notations that are alone on a line.
     Code blocks are protected from conversion.
@@ -325,8 +325,8 @@ def _convert_stock_notation(content: str) -> str:
     with _protect_code_blocks(content, "STOCK") as (protected, blocks):
         # Japanese stocks: ^5243 → https://money.note.com/companies/5243
         protected = _STOCK_JP_PATTERN.sub(r"https://money.note.com/companies/\1", protected)
-        # US stocks: $GOOG → https://money.note.com/us_companies/GOOG
-        protected = _STOCK_US_PATTERN.sub(r"https://money.note.com/us_companies/\1", protected)
+        # US stocks: $GOOG → https://money.note.com/us-companies/GOOG
+        protected = _STOCK_US_PATTERN.sub(r"https://money.note.com/us-companies/\1", protected)
 
     return _restore_code_blocks(protected, blocks)
 

--- a/tests/e2e/test_embed_api.py
+++ b/tests/e2e/test_embed_api.py
@@ -371,7 +371,7 @@ class TestMoneyEmbedApiConversion:
 
         - ブラウザを起動せずにAPIのみで下書き作成
         - noteマネーURLがfigure要素に変換される
-        - embedded-service="money"属性が設定される
+        - embedded-service="oembed"属性が設定される
         """
         # Arrange - Use note社 (証券コード: 5243) as test URL
         money_url = "https://money.note.com/companies/5243"
@@ -398,7 +398,7 @@ class TestMoneyEmbedApiConversion:
             article_html = await get_article_html(article_key)
 
             # Verify embed figure is present (in raw HTML)
-            assert 'embedded-service="money"' in article_html
+            assert 'embedded-service="oembed"' in article_html
             assert f'data-src="{money_url}"' in article_html
             assert "embedded-content-key=" in article_html
         finally:
@@ -412,7 +412,7 @@ class TestMoneyEmbedApiConversion:
         """noteマネー指数URLがAPIでfigure要素に変換される.
 
         - 指数（日経平均: NKY）のURLがfigure要素に変換される
-        - embedded-service="money"属性が設定される
+        - embedded-service="oembed"属性が設定される
         """
         # Arrange - Use 日経平均 (NKY) as test URL
         money_url = "https://money.note.com/indices/NKY"
@@ -438,7 +438,7 @@ class TestMoneyEmbedApiConversion:
             article_html = await get_article_html(article_key)
 
             # Verify embed figure is present
-            assert 'embedded-service="money"' in article_html
+            assert 'embedded-service="oembed"' in article_html
             assert f'data-src="{money_url}"' in article_html
         finally:
             # Clean up created article
@@ -451,7 +451,7 @@ class TestMoneyEmbedApiConversion:
         """noteマネー投資信託URLがAPIでfigure要素に変換される.
 
         - 投資信託（eMAXIS Slim: 0331418A）のURLがfigure要素に変換される
-        - embedded-service="money"属性が設定される
+        - embedded-service="oembed"属性が設定される
         """
         # Arrange - Use eMAXIS Slim as test URL
         money_url = "https://money.note.com/investments/0331418A"
@@ -477,7 +477,7 @@ class TestMoneyEmbedApiConversion:
             article_html = await get_article_html(article_key)
 
             # Verify embed figure is present
-            assert 'embedded-service="money"' in article_html
+            assert 'embedded-service="oembed"' in article_html
             assert f'data-src="{money_url}"' in article_html
         finally:
             # Clean up created article
@@ -495,7 +495,7 @@ class TestStockNotationEmbedApiConversion:
 
         - 株価記法 ^5243 がURLに変換される
         - noteマネーURLがfigure要素に変換される
-        - embedded-service="money"属性が設定される
+        - embedded-service="oembed"属性が設定される
         """
         # Arrange - Use Japanese stock notation for note社 (証券コード: 5243)
         body = """株価記法埋め込みテスト
@@ -521,7 +521,7 @@ class TestStockNotationEmbedApiConversion:
             article_html = await get_article_html(article_key)
 
             # Verify embed figure is present (notation converted to URL then embedded)
-            assert 'embedded-service="money"' in article_html
+            assert 'embedded-service="oembed"' in article_html
             assert 'data-src="https://money.note.com/companies/5243"' in article_html
             assert "embedded-content-key=" in article_html
         finally:
@@ -536,7 +536,7 @@ class TestStockNotationEmbedApiConversion:
 
         - 株価記法 $GOOG がURLに変換される
         - noteマネーURLがfigure要素に変換される
-        - embedded-service="money"属性が設定される
+        - embedded-service="oembed"属性が設定される
         """
         # Arrange - Use US stock notation for Google
         body = """米国株記法埋め込みテスト
@@ -561,8 +561,8 @@ $GOOG
             article_html = await get_article_html(article_key)
 
             # Verify embed figure is present
-            assert 'embedded-service="money"' in article_html
-            assert 'data-src="https://money.note.com/us_companies/GOOG"' in article_html
+            assert 'embedded-service="oembed"' in article_html
+            assert 'data-src="https://money.note.com/us-companies/GOOG"' in article_html
         finally:
             # Clean up created article
             await delete_draft_with_retry(real_session, article_key)
@@ -605,9 +605,9 @@ $GOOG
             article_html = await get_article_html(article_key)
 
             # Both should be converted
-            assert article_html.count('embedded-service="money"') >= 2
+            assert article_html.count('embedded-service="oembed"') >= 2
             assert 'data-src="https://money.note.com/companies/5243"' in article_html
-            assert 'data-src="https://money.note.com/us_companies/GOOG"' in article_html
+            assert 'data-src="https://money.note.com/us-companies/GOOG"' in article_html
         finally:
             # Clean up created article
             await delete_draft_with_retry(real_session, article_key)
@@ -647,7 +647,7 @@ $GOOG
             article_html = await get_article_html(article_key)
 
             # Code block content should NOT be converted to embeds
-            assert 'embedded-service="money"' not in article_html
+            assert 'embedded-service="oembed"' not in article_html
             # Original notation should be preserved in code block
             assert "^5243" in article_html
             assert "$GOOG" in article_html

--- a/tests/unit/test_embeds.py
+++ b/tests/unit/test_embeds.py
@@ -1281,15 +1281,15 @@ class TestMoneyPattern:
         assert MONEY_PATTERN.match("https://money.note.com/companies/5243/")
 
     def test_money_us_companies_url(self) -> None:
-        """Test US stock URL detection (us_companies)."""
+        """Test US stock URL detection (us-companies)."""
         from note_mcp.api.embeds import MONEY_PATTERN
 
         # Valid US stock URLs
-        assert MONEY_PATTERN.match("https://money.note.com/us_companies/GOOG")
-        assert MONEY_PATTERN.match("https://money.note.com/us_companies/AAPL")
-        assert MONEY_PATTERN.match("https://money.note.com/us_companies/MSFT")
+        assert MONEY_PATTERN.match("https://money.note.com/us-companies/GOOG")
+        assert MONEY_PATTERN.match("https://money.note.com/us-companies/AAPL")
+        assert MONEY_PATTERN.match("https://money.note.com/us-companies/MSFT")
         # With trailing slash
-        assert MONEY_PATTERN.match("https://money.note.com/us_companies/GOOG/")
+        assert MONEY_PATTERN.match("https://money.note.com/us-companies/GOOG/")
 
     def test_money_indices_url(self) -> None:
         """Test index URL detection (indices)."""
@@ -1329,32 +1329,32 @@ class TestMoneyPattern:
 class TestGetEmbedServiceMoney:
     """Tests for get_embed_service function with noteマネー URLs."""
 
-    def test_get_embed_service_returns_money_for_companies(self) -> None:
-        """Test that get_embed_service returns 'money' for Japanese stock URLs."""
+    def test_get_embed_service_returns_oembed_for_companies(self) -> None:
+        """Test that get_embed_service returns 'oembed' for Japanese stock URLs."""
         from note_mcp.api.embeds import get_embed_service
 
-        assert get_embed_service("https://money.note.com/companies/5243") == "money"
-        assert get_embed_service("https://money.note.com/companies/7203") == "money"
+        assert get_embed_service("https://money.note.com/companies/5243") == "oembed"
+        assert get_embed_service("https://money.note.com/companies/7203") == "oembed"
 
-    def test_get_embed_service_returns_money_for_us_companies(self) -> None:
-        """Test that get_embed_service returns 'money' for US stock URLs."""
+    def test_get_embed_service_returns_oembed_for_us_companies(self) -> None:
+        """Test that get_embed_service returns 'oembed' for US stock URLs."""
         from note_mcp.api.embeds import get_embed_service
 
-        assert get_embed_service("https://money.note.com/us_companies/GOOG") == "money"
-        assert get_embed_service("https://money.note.com/us_companies/AAPL") == "money"
+        assert get_embed_service("https://money.note.com/us-companies/GOOG") == "oembed"
+        assert get_embed_service("https://money.note.com/us-companies/AAPL") == "oembed"
 
-    def test_get_embed_service_returns_money_for_indices(self) -> None:
-        """Test that get_embed_service returns 'money' for index URLs."""
+    def test_get_embed_service_returns_oembed_for_indices(self) -> None:
+        """Test that get_embed_service returns 'oembed' for index URLs."""
         from note_mcp.api.embeds import get_embed_service
 
-        assert get_embed_service("https://money.note.com/indices/NKY") == "money"
-        assert get_embed_service("https://money.note.com/indices/TOPX") == "money"
+        assert get_embed_service("https://money.note.com/indices/NKY") == "oembed"
+        assert get_embed_service("https://money.note.com/indices/TOPX") == "oembed"
 
-    def test_get_embed_service_returns_money_for_investments(self) -> None:
-        """Test that get_embed_service returns 'money' for investment trust URLs."""
+    def test_get_embed_service_returns_oembed_for_investments(self) -> None:
+        """Test that get_embed_service returns 'oembed' for investment trust URLs."""
         from note_mcp.api.embeds import get_embed_service
 
-        assert get_embed_service("https://money.note.com/investments/0331418A") == "money"
+        assert get_embed_service("https://money.note.com/investments/0331418A") == "oembed"
 
 
 class TestGenerateEmbedHtmlMoney:
@@ -1370,7 +1370,7 @@ class TestGenerateEmbedHtmlMoney:
         # Verify required attributes
         assert "<figure" in html
         assert f'data-src="{url}"' in html
-        assert 'embedded-service="money"' in html
+        assert 'embedded-service="oembed"' in html
         assert 'contenteditable="false"' in html
         assert "embedded-content-key=" in html
         assert "</figure>" in html
@@ -1379,10 +1379,10 @@ class TestGenerateEmbedHtmlMoney:
         """Test US stock embed HTML structure."""
         from note_mcp.api.embeds import generate_embed_html
 
-        url = "https://money.note.com/us_companies/GOOG"
+        url = "https://money.note.com/us-companies/GOOG"
         html = generate_embed_html(url)
 
-        assert 'embedded-service="money"' in html
+        assert 'embedded-service="oembed"' in html
         assert f'data-src="{url}"' in html
 
     def test_money_indices_embed_structure(self) -> None:
@@ -1392,7 +1392,7 @@ class TestGenerateEmbedHtmlMoney:
         url = "https://money.note.com/indices/NKY"
         html = generate_embed_html(url)
 
-        assert 'embedded-service="money"' in html
+        assert 'embedded-service="oembed"' in html
         assert f'data-src="{url}"' in html
 
     def test_money_investments_embed_structure(self) -> None:
@@ -1402,7 +1402,7 @@ class TestGenerateEmbedHtmlMoney:
         url = "https://money.note.com/investments/0331418A"
         html = generate_embed_html(url)
 
-        assert 'embedded-service="money"' in html
+        assert 'embedded-service="oembed"' in html
         assert f'data-src="{url}"' in html
 
 
@@ -1414,6 +1414,6 @@ class TestIsEmbedUrlMoney:
         from note_mcp.api.embeds import is_embed_url
 
         assert is_embed_url("https://money.note.com/companies/5243") is True
-        assert is_embed_url("https://money.note.com/us_companies/GOOG") is True
+        assert is_embed_url("https://money.note.com/us-companies/GOOG") is True
         assert is_embed_url("https://money.note.com/indices/NKY") is True
         assert is_embed_url("https://money.note.com/investments/0331418A") is True

--- a/tests/unit/test_markdown_to_html.py
+++ b/tests/unit/test_markdown_to_html.py
@@ -820,7 +820,7 @@ https://gist.github.com/defunkt/2059
     def test_money_url_detected(self) -> None:
         """noteマネーのURLが検出される"""
         assert has_embed_url("https://money.note.com/companies/5243") is True
-        assert has_embed_url("https://money.note.com/us_companies/GOOG") is True
+        assert has_embed_url("https://money.note.com/us-companies/GOOG") is True
         assert has_embed_url("https://money.note.com/indices/NKY") is True
         assert has_embed_url("https://money.note.com/investments/0331418A") is True
 
@@ -832,28 +832,28 @@ class TestStockNotationConversion:
         """日本株記法 (^5243) がURLに変換される."""
         result = markdown_to_html("^5243")
         # Should be converted to money.note.com URL and embedded
-        assert 'embedded-service="money"' in result
+        assert 'embedded-service="oembed"' in result
         assert 'data-src="https://money.note.com/companies/5243"' in result
 
     def test_jp_stock_notation_5_digits(self) -> None:
         """5桁の日本株記法も変換される."""
         result = markdown_to_html("^12345")
-        assert 'embedded-service="money"' in result
+        assert 'embedded-service="oembed"' in result
         assert 'data-src="https://money.note.com/companies/12345"' in result
 
     def test_us_stock_notation_converted_to_url(self) -> None:
         """米国株記法 ($GOOG) がURLに変換される."""
         result = markdown_to_html("$GOOG")
-        assert 'embedded-service="money"' in result
-        assert 'data-src="https://money.note.com/us_companies/GOOG"' in result
+        assert 'embedded-service="oembed"' in result
+        assert 'data-src="https://money.note.com/us-companies/GOOG"' in result
 
     def test_us_stock_notation_various_tickers(self) -> None:
         """様々な米国株ティッカーが変換される."""
         result_aapl = markdown_to_html("$AAPL")
-        assert 'data-src="https://money.note.com/us_companies/AAPL"' in result_aapl
+        assert 'data-src="https://money.note.com/us-companies/AAPL"' in result_aapl
 
         result_msft = markdown_to_html("$MSFT")
-        assert 'data-src="https://money.note.com/us_companies/MSFT"' in result_msft
+        assert 'data-src="https://money.note.com/us-companies/MSFT"' in result_msft
 
     def test_jp_stock_notation_in_code_block_not_converted(self) -> None:
         """コードブロック内の日本株記法は変換されない."""
@@ -862,7 +862,7 @@ class TestStockNotationConversion:
 ```"""
         result = markdown_to_html(markdown)
         # Should remain as code, not embedded
-        assert 'embedded-service="money"' not in result
+        assert 'embedded-service="oembed"' not in result
         assert "^5243" in result
 
     def test_us_stock_notation_in_code_block_not_converted(self) -> None:
@@ -872,34 +872,34 @@ $GOOG
 ```"""
         result = markdown_to_html(markdown)
         # Should remain as code, not embedded
-        assert 'embedded-service="money"' not in result
+        assert 'embedded-service="oembed"' not in result
         assert "$GOOG" in result
 
     def test_jp_stock_notation_inline_code_not_converted(self) -> None:
         """インラインコード内の日本株記法は変換されない."""
         result = markdown_to_html("Use `^5243` for note stock")
         # Should remain as inline code
-        assert 'embedded-service="money"' not in result
+        assert 'embedded-service="oembed"' not in result
         assert "^5243" in result
 
     def test_us_stock_notation_inline_code_not_converted(self) -> None:
         """インラインコード内の米国株記法は変換されない."""
         result = markdown_to_html("Use `$GOOG` for Google stock")
         # Should remain as inline code
-        assert 'embedded-service="money"' not in result
+        assert 'embedded-service="oembed"' not in result
         assert "$GOOG" in result
 
     def test_jp_stock_in_text_not_converted(self) -> None:
         """文中の日本株記法は変換されない（単独行のみ対応）."""
         result = markdown_to_html("Stock code is ^5243 for note")
         # Should not be converted - only standalone lines are supported
-        assert 'embedded-service="money"' not in result
+        assert 'embedded-service="oembed"' not in result
 
     def test_us_stock_in_text_not_converted(self) -> None:
         """文中の米国株記法は変換されない（単独行のみ対応）."""
         result = markdown_to_html("Google stock is $GOOG today")
         # Should not be converted - only standalone lines are supported
-        assert 'embedded-service="money"' not in result
+        assert 'embedded-service="oembed"' not in result
 
     def test_multiple_stock_notations_converted(self) -> None:
         """複数の株価記法がそれぞれ変換される."""
@@ -913,18 +913,18 @@ $GOOG
 """
         result = markdown_to_html(markdown)
         # Both should be converted
-        assert result.count('embedded-service="money"') == 2
+        assert result.count('embedded-service="oembed"') == 2
         assert 'data-src="https://money.note.com/companies/5243"' in result
-        assert 'data-src="https://money.note.com/us_companies/GOOG"' in result
+        assert 'data-src="https://money.note.com/us-companies/GOOG"' in result
 
     def test_jp_stock_notation_invalid_length_not_converted(self) -> None:
         """3桁以下の日本株記法は変換されない."""
         result = markdown_to_html("^123")
         # 3 digits - should not match (4-5 digits required)
-        assert 'embedded-service="money"' not in result
+        assert 'embedded-service="oembed"' not in result
 
     def test_us_stock_notation_lowercase_not_converted(self) -> None:
         """小文字の米国株記法は変換されない."""
         result = markdown_to_html("$goog")
         # Lowercase - should not match (uppercase required)
-        assert 'embedded-service="money"' not in result
+        assert 'embedded-service="oembed"' not in result


### PR DESCRIPTION
## Summary

- noteマネー（株価チャート）埋め込みが表示されない問題を修正
- `embedded-service` 属性の値を `"money"` から `"oembed"` に変更（note.comフロントエンドの期待値に合致）
- 米国株URLパスを `us_companies` から `us-companies` に修正（実際のnote.com URL構造に合致）

## Test plan

- [x] ユニットテスト全パス（169テスト）
- [x] mypy型チェック通過
- [x] 実際のnote.comで日本株（`^5243`）の埋め込み表示を確認
- [x] 実際のnote.comで米国株（`$GOOG`）の埋め込み表示を確認

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)