### PR TITLE
feat: add merge-pr command and script for automated PR merging

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -1,0 +1,238 @@
+---
+description: PRのCIが完了するのを待ってからマージする
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+**Required**: PR番号（例: `45`）
+
+## Goal
+
+指定されたPRのCIチェックが完了するまで待機し、すべてのチェックがパスしたらsquash mergeを実行する。
+
+## Execution Steps
+
+### Step 1: 引数の検証
+
+`$ARGUMENTS` をパース:
+
+1. PR番号が数値であることを確認
+2. オプションフラグの検出（`--merge`, `--rebase`）
+
+**パース例**:
+- `45` → PR番号: 45, マージ方法: squash（デフォルト）
+- `45 --merge` → PR番号: 45, マージ方法: merge
+- `45 --rebase` → PR番号: 45, マージ方法: rebase
+
+未指定または非数値の場合はエラーメッセージを表示して終了:
+
+```
+⚠️ PR番号が必要です
+
+使用方法: /merge-pr <PR番号> [--merge|--rebase]
+例: /merge-pr 45
+例: /merge-pr 45 --merge（マージコミットを作成）
+例: /merge-pr 45 --rebase（リベースマージ）
+```
+
+### Step 2: PR情報の取得・検証
+
+以下のコマンドでPR情報を取得:
+
+```bash
+gh pr view <PR番号> --json number,title,state,mergeable,baseRefName,headRefName
+```
+
+取得した情報を検証:
+- **state**: `OPEN`であること（`MERGED`や`CLOSED`でないこと）
+- **mergeable**: `MERGEABLE`であること（コンフリクトがないこと）
+
+**エラー時の対応**:
+
+| 状態 | 対応 |
+|------|------|
+| PRが存在しない | `⚠️ PR #<PR番号> が見つかりません` |
+| stateがMERGED | `ℹ️ PR #<PR番号> は既にマージ済みです` |
+| stateがCLOSED | `⚠️ PR #<PR番号> はクローズされています` |
+| mergeableがCONFLICTING | `⚠️ PR #<PR番号> にコンフリクトがあります。解消してから再実行してください` |
+
+### Step 3: CIチェックの待機
+
+CIチェックの状態を確認し、完了まで待機:
+
+```bash
+gh pr checks <PR番号> --watch
+```
+
+このコマンドは:
+- すべてのチェックが完了するまでリアルタイムで状態を表示
+- 完了後に終了コードを返す（全成功: 0, 失敗あり: 非0）
+
+**出力例（待機中）**:
+```
+Some checks are still pending
+NAME                    STATUS   DESCRIPTION
+test                    pending  Waiting for status to be reported
+lint                    pass     All checks passed
+```
+
+**チェック失敗時**:
+
+```bash
+# 失敗したチェックの詳細を確認
+gh pr checks <PR番号> --json name,state,conclusion --jq '.[] | select(.conclusion == "failure" or .conclusion == "cancelled")'
+```
+
+失敗がある場合は処理を中断:
+
+```
+❌ CIチェックが失敗しました
+
+失敗したチェック:
+- test: failure
+- lint: cancelled
+
+修正してから再実行してください。
+```
+
+### Step 4: マージ可能性の最終確認
+
+CIチェック完了後、再度PRの状態を確認:
+
+```bash
+gh pr view <PR番号> --json mergeable,mergeStateStatus
+```
+
+- **mergeStateStatus**: `CLEAN`であること
+
+`BLOCKED`の場合はブロック理由を表示:
+
+```
+⚠️ マージがブロックされています
+
+理由: レビュー承認が必要です
+
+PRの要件を確認してください。
+```
+
+### Step 5: マージの実行
+
+すべての条件を満たしたらマージを実行:
+
+```bash
+# デフォルト: squash merge
+gh pr merge <PR番号> --squash --delete-branch
+
+# --merge フラグ指定時
+gh pr merge <PR番号> --merge --delete-branch
+
+# --rebase フラグ指定時
+gh pr merge <PR番号> --rebase --delete-branch
+```
+
+成功時の出力:
+
+```
+✅ PR #<PR番号> をマージしました
+
+マージ方法: squash
+ベースブランチ: main
+リモートブランチ: 削除済み
+```
+
+### Step 6: 後処理
+
+**重要**: worktreeディレクトリ内で`git worktree remove`を実行するとカレントディレクトリが削除され、その後のgitコマンドが失敗する。必ず**メインリポジトリに移動してから**後処理を行う。
+
+#### 6.1 現在の作業ディレクトリを確認
+
+```bash
+# 現在のディレクトリがworktreeかどうかを確認
+git rev-parse --git-common-dir
+```
+
+- メインリポジトリ: `.git` を返す
+- worktree: メインリポジトリの`.git`への絶対パスを返す（例: `/home/user/repo/note-mcp/.git`）
+
+#### 6.2 メインリポジトリに移動
+
+worktreeで作業している場合は、まずメインリポジトリに移動:
+
+```bash
+# メインリポジトリのパスを取得
+MAIN_REPO=$(git rev-parse --git-common-dir | sed 's/\/.git$//')
+
+# メインリポジトリに移動
+cd "$MAIN_REPO"
+```
+
+#### 6.3 mainブランチに切り替え
+
+```bash
+# mainブランチに切り替え
+git checkout main
+
+# リモートの更新を取得
+git pull origin main
+```
+
+#### 6.4 worktreeの削除
+
+マージしたブランチに対応するworktreeがある場合は削除:
+
+```bash
+# worktree一覧を取得
+git worktree list
+
+# 対応するworktreeがあるか確認（ブランチ名で検索）
+# 例: feat/123-add-feature → ../note-mcp-feat-123-add-feature
+
+# worktreeがあれば削除（メインリポジトリから実行）
+git worktree remove <worktree-path>
+
+# staleなworktree参照をクリーンアップ
+git worktree prune
+```
+
+成功時:
+
+```
+🧹 worktreeを削除しました: ../note-mcp-feat-123-add-feature
+```
+
+#### 6.5 ローカルブランチの削除
+
+worktree削除後にブランチを削除:
+
+```bash
+# マージ済みブランチを削除
+git branch -d <headRefName>
+```
+
+**注意**: worktreeを先に削除しないと、ブランチが「チェックアウト中」とみなされて削除できない。
+
+## Error Handling
+
+| エラー | 対応 |
+|--------|------|
+| PR番号未指定 | 使用方法を表示 |
+| PRが存在しない | エラーメッセージを表示 |
+| PRがマージ済み/クローズ済み | 状態を表示して終了 |
+| コンフリクトあり | 解消方法を案内 |
+| CIが失敗 | 失敗したチェックを表示 |
+| マージがブロック | ブロック理由を表示 |
+| gh未認証 | `gh auth login`を案内 |
+| worktree削除失敗 | 警告を表示するが続行 |
+
+## Notes
+
+- デフォルトのマージ方法は`--squash`（コミットを1つにまとめる）
+- `--delete-branch`により、マージ後にリモートブランチは自動削除される
+- worktreeの自動削除は`.claude/git-conventions.md`の命名規則に基づいて検出する
+- CIが進行中の場合、`gh pr checks --watch`により完了まで待機する
+- すべてのチェックがパスしないとマージは実行されない
+- **後処理の順序が重要**: メインリポジトリに移動 → mainにチェックアウト → worktree削除 → ブランチ削除

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ issue対応時は以下のワークフローに従う。
 | 4 | PR作成 | `/commit-commands:commit-push-pr` |
 | 5 | PRレビュー | `/pr-review-toolkit:review-pr` |
 | 6 | レビューコメント対応 | `/review-pr-comments` |
-| 7 | PRマージ | GitHub上で手動マージ |
+| 7 | PRマージ | `/merge-pr <PR番号>` |
 
 **ブランチ・コミット・worktree命名規則:**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,9 @@ issue対応ワークフローを自動化するスクリプト集です。
          ↓
     [レビューコメントに対応]
          ↓
-    [PRマージ]
+./scripts/merge-pr.sh            # worktreeで実行
+         ↓
+    [CI待機 → マージ → 後処理]
 ```
 
 ## スクリプト一覧
@@ -95,6 +97,26 @@ PRのレビューコメントに対応します。
 2. `/review-pr-comments` コマンドを実行
 3. レビューコメントへの対応
 
+### merge-pr.sh
+
+PRをマージします（CI完了待機付き）。
+
+```bash
+# worktreeディレクトリで実行
+./scripts/merge-pr.sh
+
+# 途中経過を表示
+./scripts/merge-pr.sh -v
+```
+
+**実行内容:**
+1. `gh pr view` でPR番号を自動検出
+2. `/merge-pr` コマンドを実行
+3. CIチェック完了まで待機
+4. squash mergeを実行
+5. リモートブランチ削除
+6. ローカルブランチ・worktree削除
+
 ### full-workflow.sh
 
 上記すべてのステップを一括で実行します。
@@ -115,6 +137,7 @@ PRのレビューコメントに対応します。
 2. complete-issue（commit + push + PR作成）
 3. review-pr（PRレビュー + コメント投稿）
 4. respond-comments（レビューコメントに対応）
+5. merge-pr（CI待機 → マージ → 後処理）
 
 ### add-worktree.sh
 
@@ -151,6 +174,7 @@ issueに対応するworktreeを作成します（setup-issue.sh から呼び出�
 | `complete-issue.sh` | worktree |
 | `review-pr.sh` | worktree |
 | `respond-comments.sh` | worktree |
+| `merge-pr.sh` | worktree |
 
 ## 前提条件
 

--- a/scripts/full-workflow.sh
+++ b/scripts/full-workflow.sh
@@ -13,6 +13,7 @@
 # 2. complete-issue（commit + push + PR作成）
 # 3. review-pr（PRレビュー + コメント投稿）
 # 4. respond-comments（レビューコメントに対応）
+# 5. merge-pr（CI待機 → マージ → 後処理）
 
 set -euo pipefail
 
@@ -58,7 +59,7 @@ echo "════════════════════════�
 echo ""
 
 # Step 1: worktree作成または検出
-echo "📦 Step 1/5: worktree準備"
+echo "📦 Step 1/6: worktree準備"
 echo "───────────────────────────────────────────────────────────────"
 
 WORKTREE_PATH=$(lib_get_worktree_path "$ISSUE_NUM")
@@ -83,7 +84,7 @@ cd "$WORKTREE_PATH"
 echo ""
 
 # Step 2: start-issue（計画立案・実装）
-echo "📝 Step 2/5: start-issue（計画立案・実装）"
+echo "📝 Step 2/6: start-issue（計画立案・実装）"
 echo "───────────────────────────────────────────────────────────────"
 
 START_ISSUE_FILE="$WORKTREE_PATH/.claude/commands/start-issue.md"
@@ -107,7 +108,7 @@ echo "✅ start-issue 完了"
 echo ""
 
 # Step 3: complete-issue（commit + push + PR作成）
-echo "📤 Step 3/5: complete-issue（commit + push + PR作成）"
+echo "📤 Step 3/6: complete-issue（commit + push + PR作成）"
 echo "───────────────────────────────────────────────────────────────"
 
 PROMPT_COMPLETE="以下のスキルを実行してください:
@@ -123,7 +124,7 @@ echo "✅ complete-issue 完了"
 echo ""
 
 # Step 4: review-pr（PRレビュー + コメント投稿）
-echo "🔍 Step 4/5: review-pr（PRレビュー + コメント投稿）"
+echo "🔍 Step 4/6: review-pr（PRレビュー + コメント投稿）"
 echo "───────────────────────────────────────────────────────────────"
 
 PR_NUM=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
@@ -141,7 +142,7 @@ else
     echo ""
 
     # Step 5: respond-comments（レビューコメントに対応）
-    echo "💬 Step 5/5: respond-comments（レビューコメントに対応）"
+    echo "💬 Step 5/6: respond-comments（レビューコメントに対応）"
     echo "───────────────────────────────────────────────────────────────"
 
     PROMPT_RESPOND="/review-pr-comments $PR_NUM"
@@ -149,6 +150,18 @@ else
 
     echo ""
     echo "✅ respond-comments 完了"
+    echo ""
+
+    # Step 6: merge-pr（CI待機 → マージ → 後処理）
+    echo "🔀 Step 6/6: merge-pr（CI待機 → マージ → 後処理）"
+    echo "───────────────────────────────────────────────────────────────"
+    echo "   (CIチェック完了まで待機します)"
+
+    PROMPT_MERGE="/merge-pr $PR_NUM"
+    lib_run_claude "$PROMPT_MERGE" "no_exec"
+
+    echo ""
+    echo "✅ merge-pr 完了"
 fi
 
 echo ""

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# merge-pr.sh - PRをマージ（CI完了待機 → マージ → 後処理）
+#
+# Usage: ./scripts/merge-pr.sh [-v|--verbose]
+#
+# Options:
+#   -v, --verbose  途中経過を表示（ツール呼び出しを含む）
+#
+# worktreeディレクトリ内で実行してください。
+# 現在のブランチに紐づくPRを自動検出します。
+#
+# 処理内容:
+# 1. CIチェックが完了するまで待機
+# 2. すべてのチェックがパスしたらsquash merge
+# 3. リモートブランチ削除
+# 4. ローカルブランチ・worktree削除
+
+set -euo pipefail
+
+# 共通ライブラリを読み込む
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+# オプション解析（evalで _LIB_VERBOSE と REMAINING_ARGS を設定）
+OUTPUT=$(lib_parse_verbose_option "$@")
+# 出力形式を検証してからeval
+if [[ ! "$OUTPUT" =~ ^_LIB_VERBOSE=(true|false)\;\ REMAINING_ARGS= ]]; then
+    echo "ERROR: Option parsing failed" >&2
+    exit 1
+fi
+eval "$OUTPUT"
+eval set -- "$REMAINING_ARGS"
+
+# 不明なオプションのチェック
+if [[ $# -gt 0 ]]; then
+    echo "⚠️ 不明なオプション: $1"
+    exit 1
+fi
+
+echo "🔍 現在のブランチからPRを検出中..."
+
+PR_NUM=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
+
+if [[ -z "$PR_NUM" ]]; then
+    echo "⚠️ 現在のブランチに紐づくPRが見つかりません"
+    echo ""
+    echo "先に complete-issue.sh を実行してPRを作成してください。"
+    exit 1
+fi
+
+echo "📍 PRを検出: #$PR_NUM"
+echo ""
+echo "🔀 merge-pr を実行中..."
+echo "   (CIチェック完了まで待機します)"
+echo ""
+
+PROMPT="/merge-pr $PR_NUM"
+
+lib_run_claude "$PROMPT"


### PR DESCRIPTION
## Summary

- Add `/merge-pr` command that waits for CI checks to complete before merging PRs
- Add `scripts/merge-pr.sh` script following existing patterns (`respond-comments.sh`)
- Extend `full-workflow.sh` from 5 to 6 steps, adding merge-pr as the final step
- Update documentation in `CLAUDE.md` and `scripts/README.md`

## Test plan

- [ ] Run `/merge-pr <PR番号>` on a PR with pending CI checks to verify waiting behavior
- [ ] Run `./scripts/merge-pr.sh` from a worktree directory
- [ ] Run `./scripts/full-workflow.sh <issue番号>` to verify full workflow integration
- [ ] Verify worktree cleanup after merge completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)