### PR TITLE
fix(#230): move to main repo before merge to support worktree

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -197,11 +197,15 @@ git pull origin main
 Step 5.1で記録した`ORIGINAL_DIR`を使用して、元のworktreeを削除:
 
 ```bash
-# ORIGINAL_DIRがworktreeだった場合のみ削除
-if [ "$ORIGINAL_DIR" != "$(pwd)" ]; then
+# Step 5.2で判定したGIT_COMMON_DIRを使用してworktreeかどうかを確認
+if [ "$GIT_COMMON_DIR" != ".git" ]; then
     # worktreeを削除
-    git worktree remove "$ORIGINAL_DIR"
-    echo "🧹 worktreeを削除しました: $ORIGINAL_DIR"
+    if git worktree remove "$ORIGINAL_DIR" 2>/dev/null; then
+        echo "🧹 worktreeを削除しました: $ORIGINAL_DIR"
+    else
+        echo "⚠️ worktreeの削除に失敗しました"
+        echo "   手動で削除: git worktree remove $ORIGINAL_DIR --force"
+    fi
 
     # staleなworktree参照をクリーンアップ
     git worktree prune

--- a/.claude/git-conventions.md
+++ b/.claude/git-conventions.md
@@ -171,4 +171,5 @@ git worktree remove ../note-mcp-feat-123-add-auth
 | `.claude/commands/start-issue.md` | リンク参照 | Step 3でロジックのみ記述 |
 | `.claude/commands/add-worktree.md` | リンク参照 | Worktree命名規則を参照 |
 | `.claude/skills/issue-reporter/SKILL.md` | リンク参照 | パースパターンを参照 |
+| `.claude/commands/merge-pr.md` | リンク参照 | worktree命名規則を参照 |
 | `docs/development/contributing.md` | リンク参照 | コントリビューションの流れ |


### PR DESCRIPTION
## Summary
- worktreeディレクトリ内で`gh pr merge --delete-branch`を実行すると失敗する問題に対応
- メインリポジトリへの移動ステップをマージ実行前（Step 5）に移動
- 後処理の手順を簡略化し、より安全なワークフローを提供

## Test plan
- [ ] worktreeディレクトリから`/merge-pr`を実行してマージが成功することを確認
- [ ] メインリポジトリから`/merge-pr`を実行しても正常に動作することを確認
- [ ] マージ後にworktreeが正しく削除されることを確認

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)