### PR TITLE
feat(#226): add GitHub repository embed support

### DIFF
--- a/src/note_mcp/api/embeds.py
+++ b/src/note_mcp/api/embeds.py
@@ -71,8 +71,8 @@ def get_embed_service(url: str) -> str | None:
         url: The URL to check.
 
     Returns:
-        Service type ('youtube', 'twitter', 'note', 'gist', 'oembed',
-        'external-article', 'githubRepository') or None if unsupported.
+        Service type ('youtube', 'twitter', 'note', 'gist', 'githubRepository',
+        'oembed', 'external-article') or None if unsupported.
     """
     if YOUTUBE_PATTERN.match(url):
         return "youtube"
@@ -80,8 +80,8 @@ def get_embed_service(url: str) -> str | None:
         return "twitter"
     if NOTE_PATTERN.match(url):
         return "note"
-    # Check GIST_PATTERN before GITHUB_REPO_PATTERN to avoid gist.github.com
-    # being matched by the more general github.com pattern
+    # GIST_PATTERN is checked before GITHUB_REPO_PATTERN for clarity,
+    # though the patterns are mutually exclusive (gist.github.com vs github.com)
     if GIST_PATTERN.match(url):
         return "gist"
     if GITHUB_REPO_PATTERN.match(url):

--- a/tests/unit/test_embeds.py
+++ b/tests/unit/test_embeds.py
@@ -1715,13 +1715,22 @@ class TestGitHubRepoPattern:
         assert not GITHUB_REPO_PATTERN.match("https://github.com/user/repo/pull/123")
         assert not GITHUB_REPO_PATTERN.match("https://github.com/user/repo/blob/main/file.py")
 
-    def test_github_repo_pattern_rejects_www(self) -> None:
+    def test_github_repo_pattern_accepts_www(self) -> None:
         """Test that www.github.com is also accepted."""
         from note_mcp.api.embeds import GITHUB_REPO_PATTERN
 
         # www.github.com should be accepted
         assert GITHUB_REPO_PATTERN.match("https://www.github.com/user/repo")
         assert GITHUB_REPO_PATTERN.match("http://www.github.com/user/repo")
+
+    def test_github_repo_pattern_with_uppercase(self) -> None:
+        """Test that repository URLs with uppercase characters are accepted."""
+        from note_mcp.api.embeds import GITHUB_REPO_PATTERN
+
+        # Uppercase in owner/repo names should be accepted
+        assert GITHUB_REPO_PATTERN.match("https://github.com/Anthropic/Claude")
+        assert GITHUB_REPO_PATTERN.match("https://github.com/Microsoft/TypeScript")
+        assert GITHUB_REPO_PATTERN.match("https://github.com/OWNER/REPO")
 
 
 class TestGetEmbedServiceGitHubRepo:


### PR DESCRIPTION
## Summary
- Add support for embedding GitHub repository URLs (github.com/owner/repo) in note.com articles
- Use 'githubRepository' service type via the /v2/embed_by_external_api endpoint
- Ensure gist.github.com URLs continue to use the 'gist' service type (pattern priority)

## Test plan
- [x] Add unit tests for GITHUB_REPO_PATTERN regex matching
- [x] Add tests for get_embed_service returning 'githubRepository'
- [x] Add tests for generate_embed_html with GitHub repo URLs
- [x] Add tests for fetch_embed_key using v2 endpoint with correct service type
- [x] Add tests verifying gist URLs are not confused with repo URLs
- [ ] Run full test suite: `uv run pytest`
- [ ] Run type checking: `uv run mypy .`

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)