### PR TITLE
docs: separate embed examples into dedicated file

### DIFF
--- a/docs/features/embed.md
+++ b/docs/features/embed.md
@@ -76,12 +76,12 @@ https://www.youtube.com/watch?v=example
 
 ## 参考記事（リンクのみ）
 
-https://zenn.dev/example/articles/example
+https://qiita.com/example/items/example
 ```
 
 上記の例では:
 - YouTubeリンク → 埋め込みプレーヤーとして表示
-- Zennリンク → 通常のリンクテキストとして表示
+- Qiitaリンク → 通常のリンクテキストとして表示（非対応サービス）
 
 ### リンクテキストの指定
 

--- a/examples/sample_article.md
+++ b/examples/sample_article.md
@@ -90,35 +90,7 @@ print(f"タグ: {article.tags}")
 
 ## 埋め込み
 
-対応サービスのURLを単独の行に記述すると、埋め込みウィジェットに変換されます。
-
-### YouTube埋め込み
-
-https://www.youtube.com/watch?v=NMHcEDcympM
-
-### Twitter/X埋め込み
-
-https://x.com/patraqushe/status/1326880858007990275
-
-### note.com記事埋め込み
-
-https://note.com/drillan/n/n7379c02632c9
-
-### GitHub Gist埋め込み
-
-https://gist.github.com/drillan/71aab0a37b413be66bedf6c011d7cd37
-
-### noteマネー（株価チャート）埋め込み
-
-URL方式でnote社の株価チャートを埋め込み：
-
-https://money.note.com/companies/5243
-
-株価記法でも埋め込めます（日本株は`^証券コード`、米国株は`$ティッカー`）：
-
-^5243
-
-$GOOG
+埋め込み機能の詳細なサンプルは [sample_embeds.md](./sample_embeds.md) を参照してください。
 
 ## 水平線
 
@@ -162,8 +134,7 @@ $${\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}}$$
 6. テキスト配置（中央・右・左寄せ）
 7. 数式（KaTeX）記法
 8. ルビ（ふりがな）記法
-9. 埋め込み（YouTube、Twitter/X、note.com記事、GitHub Gist、株価チャート）
-10. 株価記法（`^証券コード`、`$ティッカー`）
+9. 埋め込み機能（詳細は [sample_embeds.md](./sample_embeds.md) を参照）
 
 ---
 

--- a/examples/sample_embeds.md
+++ b/examples/sample_embeds.md
@@ -1,0 +1,63 @@
+---
+title: note-mcp 埋め込みサンプル
+tags:
+  - note-mcp
+  - 埋め込み
+  - embed
+---
+
+この記事は note-mcp の埋め込み機能をテストするためのサンプルです。
+
+対応サービスのURLを単独の行に記述すると、埋め込みウィジェットに変換されます。
+
+## 動画
+
+### YouTube埋め込み
+
+https://www.youtube.com/watch?v=NMHcEDcympM
+
+## SNS
+
+### Twitter/X埋め込み
+
+https://x.com/patraqushe/status/1326880858007990275
+
+## 記事
+
+### note.com記事埋め込み
+
+https://note.com/drillan/n/n7379c02632c9
+
+### Zenn.dev記事埋め込み
+
+https://zenn.dev/driller/articles/0669cf98e07ffa
+
+## コード
+
+### GitHub Gist埋め込み
+
+https://gist.github.com/drillan/71aab0a37b413be66bedf6c011d7cd37
+
+## プレゼンテーション
+
+### Google Slides埋め込み
+
+https://docs.google.com/presentation/d/1W543BSd-hHANrJOzCPyNf-r3x0s5s7ljc9xA7a7x960/edit
+
+### SpeakerDeck埋め込み
+
+https://speakerdeck.com/ajstarks/dchart-charts-from-deck-markup
+
+## 金融
+
+### noteマネー（株価チャート）埋め込み
+
+URL方式でnote社の株価チャートを埋め込み：
+
+https://money.note.com/companies/5243
+
+株価記法でも埋め込めます（日本株は`^証券コード`、米国株は`$ティッカー`）：
+
+^5243
+
+$GOOG


### PR DESCRIPTION
## Summary

- `examples/sample_article.md` の埋め込みセクションを新しいファイル `examples/sample_embeds.md` に分離
- 最近追加された埋め込み機能のサンプルを追加: Zenn.dev (#222), Google Slides (#224), SpeakerDeck (#223)
- ドキュメント `docs/features/embed.md` の古い例を修正（Zenn.dev は埋め込み対応済みのため、非対応サービスの例を Qiita に変更）

## Test plan

- [ ] `examples/sample_embeds.md` が正しくパースされることを確認
- [ ] 新しい埋め込みURL（Zenn, Google Slides, SpeakerDeck）が正常に動作することを確認
- [ ] ドキュメントの説明が正確であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)