### PR TITLE
chore: remove pr-review-toolkit plugin from enabled plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,6 @@
   },
   "enabledPlugins": {
     "code-review@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true,
     "ralph-wiggum@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Remove pr-review-toolkit plugin from `.claude/settings.json` enabled plugins list

## Test plan
- [x] Verify .claude/settings.json is valid JSON
- [ ] Confirm Claude Code operates correctly without the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)