### PR TITLE
docs(#256): add GitHub Repository to test URLs and sample embeds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ note.comはルビ（ふりがな）記法をサポートしています。
 | X (Twitter) | https://x.com/patraqushe/status/1326880858007990275 |
 | note.com | https://note.com/drillan/n/n7379c02632c9 |
 | GitHub Gist | https://gist.github.com/drillan/71aab0a37b413be66bedf6c011d7cd37 |
+| GitHub Repository | https://github.com/drillan/note-mcp |
 
 ## Available Skills
 

--- a/examples/sample_embeds.md
+++ b/examples/sample_embeds.md
@@ -44,6 +44,10 @@ https://fin-py.connpass.com/event/381982/
 
 ## コード
 
+### GitHub Repository埋め込み
+
+https://github.com/drillan/note-mcp
+
 ### GitHub Gist埋め込み
 
 https://gist.github.com/drillan/71aab0a37b413be66bedf6c011d7cd37


### PR DESCRIPTION
## Summary

- CLAUDE.mdのテストURL一覧にGitHub RepositoryのURLを追加
- examples/sample_embeds.mdにGitHub Repository埋め込みの例を追加

## Test plan

- [x] `mcp__note-mcp__note_create_from_file`でsample_embeds.mdから下書きを作成し、GitHub Repositoryの埋め込みが正しく変換されることを確認済み

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)